### PR TITLE
Welcome page template, copy, route

### DIFF
--- a/client/templates/other/welcome.html
+++ b/client/templates/other/welcome.html
@@ -1,0 +1,71 @@
+<template name="welcome">
+  <div>
+    <section class="conatainer-fluid section-header">
+      <h1>Welcome Guide</h1>
+      <a href="{{pathFor 'all study groups'}}" class="btn btn-link">
+        <i class="fa fa-arrow-left"></i> Back to Study Groups
+      </a>
+    </section>
+
+    <section class="section">
+      <div class="container">
+        <div class="row">
+          <div class="col-sm-12 col-md-8 col-md-offset-2 section-body">
+            <p>
+              We learn better together.
+            </p>
+            <p>
+              We’re a community of independent code learners sharing knowledge & helping each other learn faster. We come from all over
+              the world. Everyone is welcome - no previous experience required.
+            </p>
+            <p>
+              CodeBuddies is a 100% volunteer-run community & our website
+              <a href="http://www.codebuddies.org">www.codebuddies.org</a> is open-sourced on
+              <a href="https://github.com/codebuddiesdotorg/codebuddies">https://github.com/codebuddiesdotorg/codebuddies</a>.
+            </p>
+            <p>This community thrives thanks to the generosity of our volunteers: Slack admin moderators, GitHub code contributors,
+              website community mentors, and generous donations via Open Collective
+              <a href="https://opencollective.com/codebuddies">https://opencollective.com/codebuddies</a>.</p>
+
+            <h2>Let's Get Started</h2>
+
+            <ul>
+
+              <li>Don't be shy! Introduce yourself in the
+                <strong>#introduce-yourself</strong> Slack channel and welcome fellow new members.
+                <em>The more we know about each other, the better we can connect and collaborate.</em> :) </li>
+              <li>Browse all our public Slack channels by clicking on the
+                <a href='https://codebuddies.slack.com/files/U04AQ6GFE/F8W3NHKS8/screen_shot_2018-01-20_at_10.25.27_pm.jpg'>“CHANNELS”</a> link in the sidebar.</li>
+              <li> Make sure to read our
+                <a href="https://codebuddies.slack.com/files/U0G92F4J0/F8VRAGD0S/CodeBuddies_Slack_Etiquette_for_General_Members">CodeBuddies Slack Etiquette for General Members</a> Log into our website
+                <a href="http://codebuddies.org">http://codebuddies.org</a>
+                using your new CodeBuddies Slack account & take a look around - or join a hangout.</li>
+              <li> Schedule a hangout yourself! (You don’t need to be an expert to collaborate.) Simply click on the
+                <strong>[Schedule a Hangout]</strong> button on the website & fill in the information. All hangouts get automatically
+                posted back to our Slack
+                <strong>#announcements</strong> channel. </li>
+              <li>Interested in going deep on topics like functional :javascript: or that special :ruby: book or blockchain?
+                Start a study group on
+                <a href="http://codebuddies.org/study-groups.Invite">codebuddies.org/study-groups</a>! All study groups created on the website get automatically posted back to
+                our Slack #announcements channel. Invite folks on Slack to join in so that you can motivate each other to
+                master your learning goal. </li>
+            </ul>
+            <p>If you have any questions about the community or the project or want to talk to an admin, feel free to ask about
+              it in the
+              <strong>#codebuddies-meta</strong> Slack channel. That’s also where discussions related to our community happen.</p>
+              <p><em>Happy learning</em></p>
+
+            <h2>Quick Links</h2>
+            <ul>
+              <li><a href="http://codebuddies.org">http://codebuddies.org</a></li>
+              <li><a href="http://codebuddies.org/faq">http://codebuddies.org/faq</a></li>
+              <li><a href="https://github.com/codebuddiesdotorg/codebuddies">https://github.com/codebuddiesdotorg/codebuddies</a></li>
+              <li><a href="https://www.facebook.com/groups/TOPSTUDYGROUP/">https://www.facebook.com/groups/TOPSTUDYGROUP/</a></li>
+              <li><a href="http://twitter.com/codebuddiesmeet">http://twitter.com/codebuddiesmeet</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+</template>

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -138,6 +138,18 @@ FlowRouter.route('/study-groups/owners-guide', {
   }
 });
 
+FlowRouter.route('/welcome', {
+  name: 'welcome',
+  action: function (params, queryParams) {
+    BlazeLayout.render('layout', {
+      top: 'header',
+      main: 'welcome',
+      footer: 'footer'
+    });
+  }
+});
+
+
 FlowRouter.route('/study-group/:studyGroupSlug/:studyGroupId', {
   name: 'study group',
   action: function(params, queryParams) {


### PR DESCRIPTION
Fixes #669

Created the route (lib/routes.js) and template (in client/templates/other) for a new "Welcome" page  and added the content found in the new #start-here Slack channel.
