### PR TITLE
Fix Issue #790: _select2.css changes

### DIFF
--- a/client/compatibilities/select2/_select2.css
+++ b/client/compatibilities/select2/_select2.css
@@ -37,9 +37,11 @@
       text-overflow: ellipsis;
       white-space: nowrap; }
   .select2-container .select2-search--inline {
-    float: left; }
+    float: left;
+    width: 250px; }
     .select2-container .select2-search--inline .select2-search__field {
       box-sizing: border-box;
+      width: 100% !important;
       border: none;
       font-size: 100%;
       margin-top: 5px;


### PR DESCRIPTION
Fixes #790.

Tested on Chrome & Firefox across a variety of screen sizes.

2 lines changed -- 

The main fix is `width: 100% !important`. This overrides the previous inline style of `width: 100px`. 

However, this causes it to inherit the width of the parent element, which seems to be a fixed width of 224px. The last letter gets cut off. So, I just upped it to `width: 250px;`

I tried dynamic widths like `width: 100%` and they made the height go bonkers. So, instead of editing the entire file to accommodate that, I thought this hacky fix would be fine. This doesn't affect anything once the channels are chosen, but if the placeholder text ever gets changed in the future, it may get cut off again.

Hopefully, this is good enough?