### PR TITLE
solving issue: #837 overflow problem of bigger links in discussion thread

### DIFF
--- a/client/css/_discussion.scss
+++ b/client/css/_discussion.scss
@@ -55,6 +55,6 @@
 .preview-pane {
   padding: 6px 12px;
 }
-p{
+p {
   overflow-wrap: break-word;
 }

--- a/client/css/_discussion.scss
+++ b/client/css/_discussion.scss
@@ -55,3 +55,6 @@
 .preview-pane {
   padding: 6px 12px;
 }
+p{
+  overflow-wrap: break-word;
+}


### PR DESCRIPTION
to solve the overflow problem of long URLs on discussion threads
Fixes #\<837\>
