### PR TITLE
Fix Mixed Content Error

### DIFF
--- a/client/head.html
+++ b/client/head.html
@@ -7,7 +7,7 @@
   <link rel="manifest" href="/manifest.json">
   <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
   <meta name="theme-color" content="#ffffff">
-  <link rel="stylesheet" href="http://cdn.materialdesignicons.com/1.5.54/css/materialdesignicons.min.css">
+  <link rel="stylesheet" href="https://cdn.materialdesignicons.com/1.5.54/css/materialdesignicons.min.css">
 
   <meta name="keywords" content="code buddy, Code Buddies, peer-to-peer organized, learning community, coding, programming, educational hangouts, hangouts listing, study partners">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">


### PR DESCRIPTION
Fixes #863 .

Uses the https link of materialdesignicons.min.css to avoid a mixed content error
