### PR TITLE
Fixed issue #861

### DIFF
--- a/client/templates/home/home_logged_out.html
+++ b/client/templates/home/home_logged_out.html
@@ -234,10 +234,8 @@
         <div class="col-md-12">
           <h2>Start learning with us now!</h2>
           <div class="join-slack">
-            <div class="slack-invite">
-              <script async defer src="https://codebuddiesmeet.herokuapp.com/slackin.js?large"></script>
-            </div>
-            <p>Sign in with <a href="#" class="signIn link">Slack</a> or <a href="#" class="signInGithub link">Github</a>.
+            <p>Get your Slack invite <a href="http://codebuddiesmeet.herokuapp.com" class="link" target="_blank">here</a>.
+            <br />Sign in with <a href="#" class="signIn link">Slack</a> or <a href="#" class="signInGithub link">Github</a>.
             <br />Select <strong>CodeBuddies</strong> or sign into the <strong>codebuddies</strong>.slack.com team.</p>
           </div>
         </div>

--- a/client/templates/home/home_logged_out.html
+++ b/client/templates/home/home_logged_out.html
@@ -234,7 +234,7 @@
         <div class="col-md-12">
           <h2>Start learning with us now!</h2>
           <div class="join-slack">
-            <p>Get your Slack invite <a href="http://codebuddiesmeet.herokuapp.com" class="link" target="_blank">here</a>.
+            <p>Get your Slack invite <a href="https://codebuddiesmeet.herokuapp.com" class="link" target="_blank">here</a>.
             <br />Sign in with <a href="#" class="signIn link">Slack</a> or <a href="#" class="signInGithub link">Github</a>.
             <br />Select <strong>CodeBuddies</strong> or sign into the <strong>codebuddies</strong>.slack.com team.</p>
           </div>


### PR DESCRIPTION
Fixes #861.

The [bug](https://github.com/codebuddies/codebuddies/issues/861) that caused the clicking on second  **Get your Slack invite here** button opens the box at the top of the page was eliminated. 

Now the second **Get your Slack invite here** button simply redirects to [http://codebuddiesmeet.herokuapp.com](http://codebuddiesmeet.herokuapp.com). The link is opening in other window of the browser.
