### PR TITLE
Enable docker containers for PR's

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,3 +1,3 @@
 sut:
   build: .
-  command: env
+  command: echo "DONE"

--- a/hooks/post_test
+++ b/hooks/post_test
@@ -1,0 +1,11 @@
+#!/bin/bash
+echo "getting commit ID"
+ID=$(git rev-parse HEAD)
+echo $ID
+PR_NUMBER=$(docker run --rm nalbina/jq sh -c "curl https://api.github.com/repos/codebuddies/codebuddies/pulls | jq '.[]  | select(.head.sha == \"$ID\") | .number'")
+RECENT_ID=$(docker images -q | sed -n 2p)
+echo $PR_NUMBER
+if [ -n "$PR_NUMBER" ]; then
+    docker tag $RECENT_ID codebuddiesdotorg/codebuddies:PR_$PR_NUMBER   
+    docker push codebuddiesdotorg/codebuddies:PR_$PR_NUMBER
+fi


### PR DESCRIPTION
This will effectively tag pull requests on commit using docker-hub.
I have added a dummy `docker-compose.test.yml` in order to trigger the `post_test` hook.
What this will do is push a docker container to `codebuddiesdotorg/codebuddies:PR_$PRNUMBER` which we can then take from there for demo purposes.