### PR TITLE
Format labels and buttons in profile Hangouts Completed

### DIFF
--- a/client/css/_buttons.scss
+++ b/client/css/_buttons.scss
@@ -116,8 +116,8 @@
   @include font-face(700, 15px, bold, $bg-white);
   background-color: $cta-blue;
   display: block;
-  height: 36px;
   margin: 10px auto;
+  white-space: normal;
 
   &:hover {
     color: $white;

--- a/client/css/_profile.scss
+++ b/client/css/_profile.scss
@@ -124,6 +124,10 @@
     font-weight: 600;
     letter-spacing: .2px;
   }
+  .label {
+    white-space: normal;
+  }
+
 }
 
 .profile-learnings {


### PR DESCRIPTION
Override boostrap properties that created overflow in labels and buttons by adding white-space:normal properties.
Allows buttons and labels to sit nicely in their designated columns.

Format changes to spaces

Fixes #851 

Styling of buttons and labels in the hangouts completed profile page were overflowing. Overriding bootstrap's .label and .btn properties allows for text in buttons and labels to stay formatted in their designated columns. 

![851_issue](https://user-images.githubusercontent.com/15572567/40146489-9ab54c6a-591a-11e8-87a6-2c7e6352eca3.png)
![851_fix](https://user-images.githubusercontent.com/15572567/40146497-9fe21628-591a-11e8-81db-d0cd3ef08eb2.png)

