### PR TITLE
fix (jitsi frame): missing username

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -83,8 +83,6 @@ meteorhacks:meteorx@1.4.1
 meteorhacks:picker@1.0.3
 meteorhacks:ssr@2.2.0
 meteorspark:util@0.2.0
-meteortesting:browser-tests@1.0.0
-meteortesting:mocha@1.0.0
 meteortoys:toykit@2.2.1
 minifier-js@2.3.4
 minimongo@1.4.4
@@ -114,7 +112,6 @@ patrickml:swal@1.0.0
 peppelg:bootstrap-3-modal@1.0.4
 percolate:synced-cron@1.3.0
 practicalmeteor:chai@2.1.0_1
-practicalmeteor:mocha-core@1.0.1
 promise@0.10.2
 raix:eventemitter@0.1.3
 random@1.1.0

--- a/client/templates/hangout/hangout-frame.js
+++ b/client/templates/hangout/hangout-frame.js
@@ -105,7 +105,8 @@ Template.hangoutFrame.events({
   "click .load-hangout": function(event, template) {
     const data = {
       room: this._id || template.data.hroom,
-      username: Meteor.user().username || template.data.huser,
+      username:
+        (Meteor.user() && Meteor.user().username) || template.data.huser,
       type: template.data.htype || this.type,
       avatar: template.data.havatar || Meteor.user().profile.avatar.default
     };


### PR DESCRIPTION
Fixes #898 

This fixes the error `Cannot read property 'username' of null`.