### PR TITLE
Solves issue 903: make sure video is always muted by default, even fo…

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -83,8 +83,6 @@ meteorhacks:meteorx@1.4.1
 meteorhacks:picker@1.0.3
 meteorhacks:ssr@2.2.0
 meteorspark:util@0.2.0
-meteortesting:browser-tests@1.0.0
-meteortesting:mocha@1.0.0
 meteortoys:toykit@2.2.1
 minifier-js@2.3.4
 minimongo@1.4.4
@@ -114,7 +112,6 @@ patrickml:swal@1.0.0
 peppelg:bootstrap-3-modal@1.0.4
 percolate:synced-cron@1.3.0
 practicalmeteor:chai@2.1.0_1
-practicalmeteor:mocha-core@1.0.1
 promise@0.10.2
 raix:eventemitter@0.1.3
 random@1.1.0

--- a/client/templates/hangout/hangout-frame.html
+++ b/client/templates/hangout/hangout-frame.html
@@ -8,7 +8,7 @@
 </div>
 
 <div class="alert alert-info margin-top-1 margin-bottom-1">
-  <p class="align-center">If you're seeing a blank screen, <a href="https://meet.jit.si/cb{{_id}}" target="_blank" id="joinHere">join here.</a> (New to Jitsi? Check out <a href="/images/codebuddies_jitsi_diagram.jpg" target="_blank">this diagram</a>.)</p>
+  <p class="align-center">If you're seeing a blank screen, <a href="https://meet.jit.si/cb{{_id}}#config.startWithVideoMuted=true" target="_blank" id="joinHere">join here.</a> (New to Jitsi? Check out <a href="/images/codebuddies_jitsi_diagram.jpg" target="_blank">this diagram</a>.)</p>
 </div>
   <div id="hangout-container"></div>
   {{#if numParticipants}}

--- a/client/templates/hangout/hangout-frame.js
+++ b/client/templates/hangout/hangout-frame.js
@@ -21,7 +21,7 @@ Template.hangoutFrame.onCreated(function() {
     let room = "cb" + data.room;
     let width = "100%";
     let height = 550;
-    let configOverwrite = { startVideoMuted: 0 };
+    let configOverwrite = { startWithVideoMuted: true };
     let interfaceConfigOverwrite = {};
     let htmlElement = document.getElementById("hangout-container");
 


### PR DESCRIPTION
…r first participants. The fix was that  was outdated and we needed . Also, one can set a meet.jit.si link to default true by appending #config.startWithVideoMuted=true to the URL.

Fixes #903. 