### PR TITLE
Issue 914 add testimonials

### DIFF
--- a/client/css/_home.scss
+++ b/client/css/_home.scss
@@ -434,6 +434,67 @@
     padding-bottom: 100px;
   }
 
+  .home-testimonials {
+    background: $bg-white;
+    text-align: center;
+
+    h2 {
+      text-align: center;
+      margin: 100px 0px 10px 0px;
+    }
+
+    h3 {
+      @include font-face(700, 18px, bold, $primary-grey);
+    }
+
+    p {
+      padding: 35px;
+    }
+
+    padding-bottom: 100px;
+  }
+
+  .testimonial-bubble {
+    background-color: $bg-lightgrey;
+    border-radius: 25px;
+    margin: 60px 20px;
+    position: relative;
+  }
+
+  /*testimonial-bubble triangle*/
+  .bubble-left:after {
+    content: "";
+    position: absolute;
+    bottom: -25px;
+    right: 50px;
+    border-width: 25px 25px 0;
+    border-style: solid;
+    border-color: $bg-lightgrey transparent;
+  }
+
+  .bubble-right:after {
+    content: "";
+    position: absolute;
+    bottom: -25px;
+    left: 50px;
+    border-width: 25px 25px 0;
+    border-style: solid;
+    border-color: $bg-lightgrey transparent;
+  }
+
+  .testimonial {
+    font-size: 1.35em;
+    line-height: 1.1em;
+    text-align: left;
+  }
+
+  .quote-icons {
+    color: $warm-grey;
+    float: left;
+    padding: 20px 10px 90px 20px;
+    font-size: 1.2em;
+  }
+
   .home-ask {
     padding: 60px 0px;
     text-align: center;

--- a/client/css/_home.scss
+++ b/client/css/_home.scss
@@ -483,7 +483,7 @@
   }
 
   .testimonial {
-    font-size: 1.35em;
+    font-size: 1.20em;
     line-height: 1.1em;
     text-align: left;
   }

--- a/client/templates/home/home_logged_out.html
+++ b/client/templates/home/home_logged_out.html
@@ -233,7 +233,7 @@
       <div class="row">
         <div class="col-md-12">
           <h2>Testimonials</h2>
-          <p class="align-center">Don't just take our word for it, see what some of our wonderful users have to say about CodeBuddies.</p>
+          <p class="align-center">Don't just take our word for it; these are what some of our members have said anonymously about CodeBuddies.</p>
           <div class="col-md-6">
               <div class="testimonial-bubble bubble-left">
                 <div class="quote-icons">

--- a/client/templates/home/home_logged_out.html
+++ b/client/templates/home/home_logged_out.html
@@ -228,6 +228,57 @@
     </div>
   </div>
 
+  <div class="section home-testimonials">
+    <div class="container">
+      <div class="row">
+        <div class="col-md-12">
+          <h2>Testimonials</h2>
+          <p class="align-center">Don't just take our word for it, see what some of our wonderful users have to say about CodeBuddies.</p>
+          <div class="col-md-6">
+              <div class="testimonial-bubble bubble-left">
+                <div class="quote-icons">
+                  <i class="fa fa-quote-left"></i><i class="fa fa-quote-right"></i>
+                </div>
+                <p class="testimonial">CodeBuddies is a place where people of all kinds meet up to advance their jobs, skills, and knowledge as a team.</p>
+              </div>
+              <div class="testimonial-bubble bubble-left">
+                <div class="quote-icons">
+                  <i class="fa fa-quote-left"></i><i class="fa fa-quote-right"></i>
+                </div>
+                <p class="testimonial">CodeBuddies has helped me by giving me a place to talk about coding without being judged by who I am and what languages and skills I’m learning.</p>
+              </div>
+              <div class="testimonial-bubble bubble-left">
+                <div class="quote-icons">
+                  <i class="fa fa-quote-left"></i><i class="fa fa-quote-right"></i>
+                </div>
+                <p class="testimonial">I loved seeing all the positivity, especially when I was having a hair-pulling-out day. It’s great to see people helping and giving advice and genuinely being good and nice people to their fellow developers.</p>
+              </div>
+          </div>
+          <div class="col-md-6">
+            <div class="testimonial-bubble bubble-right">
+              <div class="quote-icons">
+                <i class="fa fa-quote-left"></i><i class="fa fa-quote-right"></i>
+              </div>
+              <p class="testimonial">An active Slack community with a team that genuinely cares. Useful for those learning how to code.</p>
+            </div>
+            <div class="testimonial-bubble bubble-right">
+              <div class="quote-icons">
+                <i class="fa fa-quote-left"></i><i class="fa fa-quote-right"></i>
+              </div>
+              <p class="testimonial">Very helpful to meet people also looking to improve their skills. Helpful also if you are stuck on a concept or piece of code as it can be posted as snippet for others to help resolve issue.</p>
+            </div>
+            <div class="testimonial-bubble bubble-right">
+              <div class="quote-icons">
+                <i class="fa fa-quote-left"></i><i class="fa fa-quote-right"></i>
+              </div>
+              <p class="testimonial">I work remotely with a couple international teams (much smaller US team) and it’s nice to have found some like minded people with regular hours.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <div class="section home-ask">
     <div class="container">
       <div class="row">

--- a/client/templates/home/home_logged_out.html
+++ b/client/templates/home/home_logged_out.html
@@ -233,7 +233,9 @@
       <div class="row">
         <div class="col-md-12">
           <h2>Testimonials</h2>
-          <p class="align-center">Don't just take our word for it; these are what some of our members have said anonymously about CodeBuddies.</p>
+          <p class="align-center">Don't just take our word for it; these are what some of our members
+            <a href="https://medium.com/codebuddies/codebuddies-community-survey-results-really-insightful-commentary-from-yall-8dcb36965d71" target="_blank">
+              have said anonymously</a> about CodeBuddies.</p>
           <div class="col-md-6">
               <div class="testimonial-bubble bubble-left">
                 <div class="quote-icons">


### PR DESCRIPTION
Fixes #914

https://github.com/codebuddies/codebuddies/issues/914

As previously discussed, this PR implements a basic 'Testimonials' section to the 'Logged out' homepage. The section appears towards the end of the page, between the 'FAQ' and 'Start Learning' sections.

Used pre-existing bootstrap classes to keep styling consistent, as well as fonts, font-awesome icons and existing CSS styling. 

Would be happy to make any extra tweaks or changes as required.

Thanks! :)