### PR TITLE
Fix: Unable to start app on osx

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -18,7 +18,7 @@ ecmascript@0.10.6              # Enable ECMAScript2015+ syntax in app code
 twbs:bootstrap
 mizzao:user-status
 accounts-password@1.5.0
-fourseven:scss
+fourseven:scss@4.9.0
 check@1.3.0
 ejson@1.1.0
 fortawesome:fontawesome
@@ -71,4 +71,3 @@ practicalmeteor:chai
 meteortesting:browser-tests
 meteortesting:mocha
 practicalmeteor:mocha-core
-

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -46,7 +46,7 @@ email@1.2.3
 erasaur:meteor-lodash@4.0.0
 es5-shim@4.7.3
 fortawesome:fontawesome@4.7.0
-fourseven:scss@3.13.0
+fourseven:scss@4.9.0
 gadicohen:robots-txt@0.0.10
 gadicohen:sitemaps@0.0.26
 geojson-utils@1.0.10
@@ -143,7 +143,7 @@ templating@1.3.2
 templating-compiler@1.3.3
 templating-runtime@1.3.2
 templating-tools@1.1.2
-themeteorchef:bert@2.1.1
+themeteorchef:bert@2.1.2
 tracker@1.1.3
 tsega:bootstrap3-datetimepicker@4.17.37_1
 twbs:bootstrap@3.3.6

--- a/client/css/_sponsor.scss
+++ b/client/css/_sponsor.scss
@@ -15,7 +15,6 @@
     margin-top: 10px;
   }
 
-  ,
   a {
     text-decoration: underline;
     color: $white;
@@ -33,7 +32,6 @@
     margin-top: 10px;
   }
 
-  ,
   a {
     text-decoration: underline;
     color: $secondary-grey;


### PR DESCRIPTION
For Meteor 1.6+ the fourseven:scss package should to be at 4.9.0 👇👇
<img width="704" alt="screen shot 2018-07-21 at 8 20 13 pm" src="https://user-images.githubusercontent.com/3471415/43036684-c2db774a-8d23-11e8-9f5d-3225049212c5.png">

Otherwise will throw error 👇👇
<img width="1512" alt="screen shot 2018-07-21 at 8 21 58 pm" src="https://user-images.githubusercontent.com/3471415/43036686-c836f73c-8d23-11e8-94c4-73010b0b5697.png">

Detailed screencast: http://youtu.be/jrX9SOkra4Y

