### PR TITLE
FontAwesome cleanup: use fas instead of far (pro) icons

### DIFF
--- a/client/css/_hangout_list.scss
+++ b/client/css/_hangout_list.scss
@@ -107,7 +107,7 @@
 
   label {
     input[type="radio"] {
-      ~ i.far {
+      ~ i.fas {
         &.fa-circle {
           color: $primary-grey;
           display: inline;
@@ -119,7 +119,7 @@
         }
       }
 
-      &:checked ~ i.far {
+      &:checked ~ i.fas {
         &.fa-circle {
           display: none;
         }
@@ -136,7 +136,7 @@
       padding-left: 10px;
     }
 
-    &:hover input[type="radio"] ~ i.far {
+    &:hover input[type="radio"] ~ i.fas {
       color: $cta-blue;
     }
   }

--- a/client/templates/admin/report/report_discussion_modal.html
+++ b/client/templates/admin/report/report_discussion_modal.html
@@ -12,16 +12,16 @@
               <div id="hangout-options" class="col-md-12 text-left">
                 <div class="btn-group btn-group-vertical" data-toggle="buttons">
                   <label class="btn active">
-                    <input type="radio" name='report-category' value="spam" checked><i class="far fa-circle fa-2x"></i><i class="far fa-dot-circle fa-2x"></i> <span class="title"> {{_ "report hangout category spam"}}</span>
+                    <input type="radio" name='report-category' value="spam" checked><i class="fas fa-circle fa-2x"></i><i class="fas fa-dot-circle fa-2x"></i> <span class="title"> {{_ "report hangout category spam"}}</span>
                   </label>
                   <label class="btn">
-                    <input type="radio" name='report-category' value="abusive"><i class="far fa-circle fa-2x"></i><i class="far fa-dot-circle fa-2x"></i> <span class="title"> {{_ "report hangout category abusive"}}  </span>
+                    <input type="radio" name='report-category' value="abusive"><i class="fas fa-circle fa-2x"></i><i class="fas fa-dot-circle fa-2x"></i> <span class="title"> {{_ "report hangout category abusive"}}  </span>
                   </label>
                   <label class="btn">
-                    <input type="radio" name='report-category' value="inappropriate"><i class="far fa-circle fa-2x"></i><i class="far fa-dot-circle fa-2x"></i> <span class="title"> {{_ "report hangout category inappropriate"}} </span>
+                    <input type="radio" name='report-category' value="inappropriate"><i class="fas fa-circle fa-2x"></i><i class="fas fa-dot-circle fa-2x"></i> <span class="title"> {{_ "report hangout category inappropriate"}} </span>
                   </label>
                   <label class="btn">
-                    <input type="radio" name='report-category' value="offensive"><i class="far fa-circle fa-2x"></i><i class="far fa-dot-circle fa-2x"></i> <span class="title"> {{_ "report hangout category offensive"}} </span>
+                    <input type="radio" name='report-category' value="offensive"><i class="fas fa-circle fa-2x"></i><i class="fas fa-dot-circle fa-2x"></i> <span class="title"> {{_ "report hangout category offensive"}} </span>
                   </label>
                 </div>
               </div><!-- col-md-12 -->

--- a/client/templates/admin/report/report_hangout_modal.html
+++ b/client/templates/admin/report/report_hangout_modal.html
@@ -12,16 +12,16 @@
               <div id="hangout-options" class="col-md-12 text-left">
                 <div class="btn-group btn-group-vertical" data-toggle="buttons">
                   <label class="btn active">
-                    <input type="radio" name='report-category' value="spam" checked><i class="far fa-circle fa-2x"></i><i class="far fa-dot-circle fa-2x"></i> <span class="title"> {{_ "report hangout category spam"}}</span>
+                    <input type="radio" name='report-category' value="spam" checked><i class="fas fa-circle fa-2x"></i><i class="fas fa-dot-circle fa-2x"></i> <span class="title"> {{_ "report hangout category spam"}}</span>
                   </label>
                   <label class="btn">
-                    <input type="radio" name='report-category' value="abusive"><i class="far fa-circle fa-2x"></i><i class="far fa-dot-circle fa-2x"></i> <span class="title"> {{_ "report hangout category abusive"}}  </span>
+                    <input type="radio" name='report-category' value="abusive"><i class="fas fa-circle fa-2x"></i><i class="fas fa-dot-circle fa-2x"></i> <span class="title"> {{_ "report hangout category abusive"}}  </span>
                   </label>
                   <label class="btn">
-                    <input type="radio" name='report-category' value="inappropriate"><i class="far fa-circle fa-2x"></i><i class="far fa-dot-circle fa-2x"></i> <span class="title"> {{_ "report hangout category inappropriate"}} </span>
+                    <input type="radio" name='report-category' value="inappropriate"><i class="fas fa-circle fa-2x"></i><i class="fas fa-dot-circle fa-2x"></i> <span class="title"> {{_ "report hangout category inappropriate"}} </span>
                   </label>
                   <label class="btn">
-                    <input type="radio" name='report-category' value="offensive"><i class="far fa-circle fa-2x"></i><i class="far fa-dot-circle fa-2x"></i> <span class="title"> {{_ "report hangout category offensive"}} </span>
+                    <input type="radio" name='report-category' value="offensive"><i class="fas fa-circle fa-2x"></i><i class="fas fa-dot-circle fa-2x"></i> <span class="title"> {{_ "report hangout category offensive"}} </span>
                   </label>
                 </div>
               </div><!-- col-md-12 -->

--- a/client/templates/discussion/discussion_card.html
+++ b/client/templates/discussion/discussion_card.html
@@ -50,11 +50,11 @@
 
       <hr>
       <h4>
-        <i class="far fa-thumbs-up {{#unless currentUser}} continue-popup {{else}} {{#if isInCollection up_votes}} voted {{else}} upvote {{/if}} {{/unless}}" aria-hidden="true"></i> <small>{{up_votes.length}}</small> &nbsp; &nbsp;
-        <i class="far fa-thumbs-down {{#unless currentUser}} continue-popup {{else}} {{#if isInCollection down_votes}} voted {{else}} downvote {{/if}} {{/unless}}" aria-hidden="true"></i> <small>{{down_votes.length}}</small> &nbsp; &nbsp;
-        <small><i class="far fa-clock" aria-hidden="true"></i> Posted on: {{dispDate created_at}} </small> &nbsp; &nbsp;
-        <small><i class="far fa-comments" aria-hidden="true"></i> {{response_count}} </small> &nbsp; &nbsp;
-        <small><i class="far fa-eye" aria-hidden="true"></i> {{views}} </small> &nbsp; &nbsp;
+        <i class="fas fa-thumbs-up {{#unless currentUser}} continue-popup {{else}} {{#if isInCollection up_votes}} voted {{else}} upvote {{/if}} {{/unless}}" aria-hidden="true"></i> <small>{{up_votes.length}}</small> &nbsp; &nbsp;
+        <i class="fas fa-thumbs-down {{#unless currentUser}} continue-popup {{else}} {{#if isInCollection down_votes}} voted {{else}} downvote {{/if}} {{/unless}}" aria-hidden="true"></i> <small>{{down_votes.length}}</small> &nbsp; &nbsp;
+        <small><i class="fas fa-clock" aria-hidden="true"></i> Posted on: {{dispDate created_at}} </small> &nbsp; &nbsp;
+        <small><i class="fas fa-comments" aria-hidden="true"></i> {{response_count}} </small> &nbsp; &nbsp;
+        <small><i class="fas fa-eye" aria-hidden="true"></i> {{views}} </small> &nbsp; &nbsp;
       </h4>
 
     </div>

--- a/client/templates/discussion/discussion_item.html
+++ b/client/templates/discussion/discussion_item.html
@@ -45,11 +45,11 @@
     </div>
     <div class="col-md-12">
       <h4>
-        <i class="far fa-thumbs-up  {{#unless currentUser}} continue-popup {{else}} {{#if isInCollection up_votes}} voted {{else}} upvote {{/if}} {{/unless}}" aria-hidden="true"></i> <small>{{up_votes.length}}</small> &nbsp; &nbsp;
-        <i class="far fa-thumbs-down {{#unless currentUser}} continue-popup {{else}} {{#if isInCollection down_votes}} voted {{else}} downvote {{/if}} {{/unless}}" aria-hidden="true"></i> <small>{{down_votes.length}}</small> &nbsp; &nbsp;
-        <small><i class="far fa-clock" aria-hidden="true"></i> Posted on : {{dispDate created_at}} </small> &nbsp; &nbsp;
-        <small><i class="far fa-comments" aria-hidden="true"></i> {{response_count}} </small> &nbsp; &nbsp;
-        <small><i class="far fa-eye" aria-hidden="true"></i> {{views}} </small> &nbsp; &nbsp;
+        <i class="fas fa-thumbs-up  {{#unless currentUser}} continue-popup {{else}} {{#if isInCollection up_votes}} voted {{else}} upvote {{/if}} {{/unless}}" aria-hidden="true"></i> <small>{{up_votes.length}}</small> &nbsp; &nbsp;
+        <i class="fas fa-thumbs-down {{#unless currentUser}} continue-popup {{else}} {{#if isInCollection down_votes}} voted {{else}} downvote {{/if}} {{/unless}}" aria-hidden="true"></i> <small>{{down_votes.length}}</small> &nbsp; &nbsp;
+        <small><i class="fas fa-clock" aria-hidden="true"></i> Posted on : {{dispDate created_at}} </small> &nbsp; &nbsp;
+        <small><i class="fas fa-comments" aria-hidden="true"></i> {{response_count}} </small> &nbsp; &nbsp;
+        <small><i class="fas fa-eye" aria-hidden="true"></i> {{views}} </small> &nbsp; &nbsp;
       </h4>
     </div>
   </div>

--- a/client/templates/discussion/discussion_response_card.html
+++ b/client/templates/discussion/discussion_response_card.html
@@ -31,9 +31,9 @@
         </div>
         <hr>
         <h4>
-          <i class="far fa-thumbs-up {{#if isInCollection up_votes}} upvoted {{else}} rupvote {{/if}}" aria-hidden="true"></i> <small>{{up_votes.length}}</small> &nbsp; &nbsp;
-          <i class="far fa-thumbs-down {{#if isInCollection down_votes}} downvoted {{else}} rdownvote {{/if}}" aria-hidden="true"></i> <small>{{down_votes.length}}</small> &nbsp; &nbsp;
-          <small><i class="far fa-clock" aria-hidden="true"></i> Posted on: {{dispDate created_at}} </small> &nbsp; &nbsp;
+          <i class="fas fa-thumbs-up {{#if isInCollection up_votes}} upvoted {{else}} rupvote {{/if}}" aria-hidden="true"></i> <small>{{up_votes.length}}</small> &nbsp; &nbsp;
+          <i class="fas fa-thumbs-down {{#if isInCollection down_votes}} downvoted {{else}} rdownvote {{/if}}" aria-hidden="true"></i> <small>{{down_votes.length}}</small> &nbsp; &nbsp;
+          <small><i class="fas fa-clock" aria-hidden="true"></i> Posted on: {{dispDate created_at}} </small> &nbsp; &nbsp;
           <small>{{#if modified_at}}(Edited){{/if}}</small> &nbsp; &nbsp;
         </h4>
 
@@ -46,7 +46,7 @@
         </div>
         <hr>
         <h4>
-          <small><i class="far fa-clock" aria-hidden="true"></i> Posted on: {{dispDate created_at}} </small> &nbsp; &nbsp;
+          <small><i class="fas fa-clock" aria-hidden="true"></i> Posted on: {{dispDate created_at}} </small> &nbsp; &nbsp;
         </h4>
       </div>
     {{/if}}

--- a/client/templates/hangout/hangout-clone.html
+++ b/client/templates/hangout/hangout-clone.html
@@ -57,13 +57,13 @@
             <div id="hangout-options" class="col-md-5 text-left">
               <div class="btn-group btn-group-vertical" data-toggle="buttons">
                 <label class="btn active">
-                  <input type="radio" name='hangout-type' value="silent" checked><i class="far fa-circle fa-2x"></i><i class="far fa-dot-circle fa-2x"></i> <span>  <i class="fas fa-microphone-slash text-danger-color type"></i><span class="title">{{_ "silent_hangout"}}</span></span>
+                  <input type="radio" name='hangout-type' value="silent" checked><i class="fas fa-circle fa-2x"></i><i class="fas fa-dot-circle fa-2x"></i> <span>  <i class="fas fa-microphone-slash text-danger-color type"></i><span class="title">{{_ "silent_hangout"}}</span></span>
                 </label>
                 <label class="btn">
-                  <input type="radio" name='hangout-type' value="teaching"><i class="far fa-circle fa-2x"></i><i class="far fa-dot-circle fa-2x"></i><span> <i class="fas fa-user text-warning-color type"></i><span class="title">{{_ "teaching_hangout"}}</span></span>
+                  <input type="radio" name='hangout-type' value="teaching"><i class="fas fa-circle fa-2x"></i><i class="fas fa-dot-circle fa-2x"></i><span> <i class="fas fa-user text-warning-color type"></i><span class="title">{{_ "teaching_hangout"}}</span></span>
                 </label>
                 <label class="btn">
-                  <input type="radio" name='hangout-type' value="collaboration"><i class="far fa-circle fa-2x"></i><i class="far fa-dot-circle fa-2x"></i><span> <i class="fas fa-users text-success-color type"></i><span class="title">{{_ "collaboration_hangout"}}</span></span>
+                  <input type="radio" name='hangout-type' value="collaboration"><i class="fas fa-circle fa-2x"></i><i class="fas fa-dot-circle fa-2x"></i><span> <i class="fas fa-users text-success-color type"></i><span class="title">{{_ "collaboration_hangout"}}</span></span>
                 </label>
               </div>
             </div>

--- a/client/templates/hangout/hangout-edit.html
+++ b/client/templates/hangout/hangout-edit.html
@@ -53,13 +53,13 @@
             <div id="hangout-options" class="col-md-5 text-left">
               <div class="btn-group btn-group-vertical" data-toggle="buttons">
                 <label class="btn active">
-                  <input type="radio" name='hangout-type' value="silent" checked><i class="far fa-circle fa-2x"></i><i class="far fa-dot-circle fa-2x"></i> <span>  <i class="fas fa-microphone-slash text-danger-color type"></i><span class="title">{{_ "silent_hangout"}}</span></span>
+                  <input type="radio" name='hangout-type' value="silent" checked><i class="fas fa-circle fa-2x"></i><i class="fas fa-dot-circle fa-2x"></i> <span>  <i class="fas fa-microphone-slash text-danger-color type"></i><span class="title">{{_ "silent_hangout"}}</span></span>
                 </label>
                 <label class="btn">
-                  <input type="radio" name='hangout-type' value="teaching"><i class="far fa-circle fa-2x"></i><i class="far fa-dot-circle fa-2x"></i><span> <i class="fas fa-user text-warning-color type"></i><span class="title">{{_ "teaching_hangout"}}</span></span>
+                  <input type="radio" name='hangout-type' value="teaching"><i class="fas fa-circle fa-2x"></i><i class="fas fa-dot-circle fa-2x"></i><span> <i class="fas fa-user text-warning-color type"></i><span class="title">{{_ "teaching_hangout"}}</span></span>
                 </label>
                 <label class="btn">
-                  <input type="radio" name='hangout-type' value="collaboration"><i class="far fa-circle fa-2x"></i><i class="far fa-dot-circle fa-2x"></i><span> <i class="fas fa-users text-success-color type"></i><span class="title">{{_ "collaboration_hangout"}}</span></span>
+                  <input type="radio" name='hangout-type' value="collaboration"><i class="fas fa-circle fa-2x"></i><i class="fas fa-dot-circle fa-2x"></i><span> <i class="fas fa-users text-success-color type"></i><span class="title">{{_ "collaboration_hangout"}}</span></span>
                 </label>
               </div>
             </div>

--- a/client/templates/hangout/hangout-item.html
+++ b/client/templates/hangout/hangout-item.html
@@ -5,7 +5,7 @@
       <div class="col-md-12">
         <label class="name">
         {{#if isHangoutInProgress start end}}
-          &nbsp; &nbsp;<i class="far fa-dot-circle fa text-danger faa-burst animated"></i> &nbsp;
+          &nbsp; &nbsp;<i class="fas fa-dot-circle fa text-danger faa-burst animated"></i> &nbsp;
           <a href="{{pathFor 'hangout' hangoutId=_id }}" class="hangout-topic {{# if isHangoutCompleted end }}completed{{/if}}"> {{topic}} </a>
         {{ else }}
           <a href="{{pathFor 'hangout' hangoutId=_id }}" class="hangout-topic {{# if isHangoutCompleted end }}completed{{/if}}"> {{topic}} </a>
@@ -64,7 +64,7 @@
 
 
       <p class="status"><label><i class="fas {{getHangoutTypeSign type}}"></i> Started by <a href="{{pathFor 'profile' name=host.name userId=host.id}}" class="{{#unless currentUser}} continue-popup {{/unless}}">{{host.name}}</a></label></p>
-      <p class="status"><label><i class="far fa-calendar-alt fa-lg"></i> {{getHangoutStartDateTime start}} -
+      <p class="status"><label><i class="fas fa-calendar-alt fa-lg"></i> {{getHangoutStartDateTime start}} -
 
         {{#if isHangoutEndTimeTBA start end}}
           To Be Announced
@@ -72,7 +72,7 @@
           {{getHangoutEndDateTime end}}
         {{/if}}
           |
-         {{users.length}} Joined  {{#if views}} | <i class="far fa-eye" aria-hidden="true" data-toggle="tooltip" title="Views" ></i> {{views}} {{/if}}</label> </p>
+         {{users.length}} Joined  {{#if views}} | <i class="fas fa-eye" aria-hidden="true" data-toggle="tooltip" title="Views" ></i> {{views}} {{/if}}</label> </p>
       <p class="overflowtext">{{ getDescriptionTruncated description }}</p>
     </div>
 

--- a/client/templates/hangout/hangout-modal.html
+++ b/client/templates/hangout/hangout-modal.html
@@ -58,13 +58,13 @@
             <div id="hangout-options" class="col-md-5 text-left">
               <div class="btn-group btn-group-vertical" data-toggle="buttons">
                 <label class="btn active" id="sId">
-                  <input  type="radio" name='hangout-type' value="silent" checked><i class="far fa-circle fa-2x"></i><i class="far fa-dot-circle fa-2x"></i> <span>  <i class="fas fa-microphone-slash text-danger-color type"></i><span class="title">{{_ "silent_hangout"}}</span></span>
+                  <input  type="radio" name='hangout-type' value="silent" checked><i class="fas fa-circle fa-2x"></i><i class="fas fa-dot-circle fa-2x"></i> <span>  <i class="fas fa-microphone-slash text-danger-color type"></i><span class="title">{{_ "silent_hangout"}}</span></span>
                 </label>
                 <label class="btn" id="tId">
-                  <input  type="radio" name='hangout-type' value="teaching"><i class="far fa-circle fa-2x"></i><i class="far fa-dot-circle fa-2x"></i><span> <i class="fas fa-user text-warning-color type"></i><span class="title">{{_ "teaching_hangout"}}</span></span>
+                  <input  type="radio" name='hangout-type' value="teaching"><i class="fas fa-circle fa-2x"></i><i class="fas fa-dot-circle fa-2x"></i><span> <i class="fas fa-user text-warning-color type"></i><span class="title">{{_ "teaching_hangout"}}</span></span>
                 </label>
                 <label class="btn" id="cId">
-                  <input  type="radio" name='hangout-type' value="collaboration"><i class="far fa-circle fa-2x"></i><i class="far fa-dot-circle fa-2x"></i><span> <i class="fas fa-users text-success-color type"></i><span class="title">{{_ "collaboration_hangout"}}</span></span>
+                  <input  type="radio" name='hangout-type' value="collaboration"><i class="fas fa-circle fa-2x"></i><i class="fas fa-dot-circle fa-2x"></i><span> <i class="fas fa-users text-success-color type"></i><span class="title">{{_ "collaboration_hangout"}}</span></span>
                 </label>
               </div>
               <div class="descriptionHide" id="d1">

--- a/client/templates/hangout/hangout.html
+++ b/client/templates/hangout/hangout.html
@@ -26,7 +26,7 @@
 
               {{topic}}
 
-              {{#if views}} <span class="view"><i class="far fa-eye" aria-hidden="true" data-toggle="tooltip" title="Views" > </i> {{views}}</span> {{/if}}
+              {{#if views}} <span class="view"><i class="fas fa-eye" aria-hidden="true" data-toggle="tooltip" title="Views" > </i> {{views}}</span> {{/if}}
 
             </h2>
 
@@ -43,7 +43,7 @@
 
             <!--  hangout date time -->
             <p class="date-holder">
-              <i class="far fa-clock" aria-hidden="true"></i>
+              <i class="fas fa-clock" aria-hidden="true"></i>
               <strong>{{getHangoutStartDateDay start}}</strong>
               <br />
 
@@ -83,7 +83,7 @@
           <div class="col-md-9 hangout-body">
             {{# unless isHangoutCompleted end}}
               <p class="upcoming align-center margin-top-1 load-hangout">
-                  <i class="far fa-dot-circle fa text-danger faa-burst animated"></i>{{upcomingTime start}}
+                  <i class="fas fa-dot-circle fa text-danger faa-burst animated"></i>{{upcomingTime start}}
               </p>
             {{ else }}
               <p class="upcoming align-center margin-top-1">Sorry, this hangout has ended.</p>

--- a/client/templates/hangout/hangout_action_buttons.html
+++ b/client/templates/hangout/hangout_action_buttons.html
@@ -2,8 +2,8 @@
   <div class="hangout-action-buttons">
 
     {{# unless isHangoutCompleted end }}
-      <a href="{{ googleCalendarUrl this }}" rel="noopener" target="_blank" class="btn btn-block"><i class="far fa-calendar-alt" aria-hidden="true"></i> {{_ "add_google_calendar"}}</a>
-      <a href="{{ icsDownloadLink this }}" download="hangout.ics" class="btn btn-block"><i class="far fa-calendar-alt" aria-hidden="true"></i>{{_ "add_to_icalendar"}}</a>
+      <a href="{{ googleCalendarUrl this }}" rel="noopener" target="_blank" class="btn btn-block"><i class="fas fa-calendar-alt" aria-hidden="true"></i> {{_ "add_google_calendar"}}</a>
+      <a href="{{ icsDownloadLink this }}" download="hangout.ics" class="btn btn-block"><i class="fas fa-calendar-alt" aria-hidden="true"></i>{{_ "add_to_icalendar"}}</a>
     {{/ unless }}
 
     {{# unless isHangoutCompleted end }}
@@ -35,16 +35,16 @@
     {{/ unless }}
 
   <div class="hangout-action-buttons-other">
-    <a href="#" class="{{#if currentUser}} clone-hangout {{else}} continue-popup {{/if}} btn btn-cb2"><i class="far fa-clone" aria-hidden="true"></i> Duplicate</a>
+    <a href="#" class="{{#if currentUser}} clone-hangout {{else}} continue-popup {{/if}} btn btn-cb2"><i class="fas fa-clone" aria-hidden="true"></i> Duplicate</a>
     {{#if hangoutOwner host.id}}
       <a href="#" class="edit-hangout btn btn-cb2">Edit Details</a>
-      <a href="#" class="delete-hangout btn btn-cb2"><i class="far fa-trash-alt" aria-hidden="true"></i> Cancel Hangout</a>
+      <a href="#" class="delete-hangout btn btn-cb2"><i class="fas fa-trash-alt" aria-hidden="true"></i> Cancel Hangout</a>
     {{else}}
       {{#if isInRole 'admin,moderator,volunteer' 'CB'}}
           <a href="#" class="edit-hangout btn btn-cb2">Edit Details<span class="label label-info">M</span> </a>
       {{/if}}
       {{#if isInRole 'admin,moderator' 'CB'}}
-        <a href="#" class="delete-hangout btn btn-cb2 btn-danger"><i class="far fa-trash-alt" aria-hidden="true"></i>&nbsp; Delete <span class="label label-info">M</span> </a>
+        <a href="#" class="delete-hangout btn btn-cb2 btn-danger"><i class="fas fa-trash-alt" aria-hidden="true"></i>&nbsp; Delete <span class="label label-info">M</span> </a>
       {{/if}}
     {{/if}}
 

--- a/client/templates/hangout/hangout_card.html
+++ b/client/templates/hangout/hangout_card.html
@@ -34,7 +34,7 @@
        </small>
         <small class="hangout-details details-extra">
             with {{users.length}} RSVPed <br/>
-            {{#if views}} <i class="far fa-eye" aria-hidden="true" data-toggle="tooltip" title="Views" > {{views}} views </i> {{/if}}
+            {{#if views}} <i class="fas fa-eye" aria-hidden="true" data-toggle="tooltip" title="Views" > {{views}} views </i> {{/if}}
         </small>
     </h4>
 

--- a/client/templates/hangout/support_hangout_organizer.html
+++ b/client/templates/hangout/support_hangout_organizer.html
@@ -14,7 +14,7 @@
                     <li><i class="fas fa-arrow-right" aria-hidden="true"></i> <a href="{{patreon}}" target="_blank">supporting them on Patreon <i class="fab fa-patreon"></i></a></li>
                 {{/if}}
                 {{# if nonprofit}}
-                    <li><i class="fas fa-arrow-right" aria-hidden="true"></i> <a href="{{nonprofit}}" target="_blank">supporting a non-profit they champion <i class="far fa-heart" aria-hidden="true"></i></a></li>
+                    <li><i class="fas fa-arrow-right" aria-hidden="true"></i> <a href="{{nonprofit}}" target="_blank">supporting a non-profit they champion <i class="fas fa-heart" aria-hidden="true"></i></a></li>
                 {{/if}}
             </ul>
         </div>

--- a/client/templates/other/page-not-found.html
+++ b/client/templates/other/page-not-found.html
@@ -3,7 +3,7 @@
   <div class="jumbotron align-center">
   	<div class="container">
   	  <div class="row">
-          <i class="far fa-frown fa-5x"></i>
+          <i class="fas fa-frown fa-5x"></i>
   	  		<h4>404</h4>
   	  		<h5>Page not found</h5>
   	  		<h6>The page you are looking for does not exist.</h6>

--- a/client/templates/profile/profile.html
+++ b/client/templates/profile/profile.html
@@ -81,7 +81,7 @@
                 {{/if}}
                 {{# if profile.support_links.nonprofit}}
                   <a href="{{profile.support_links.nonprofit}}" target="_blank" alt="A non-profit I support">
-                    <i class="far fa-heart" aria-hidden="true"></i>
+                    <i class="fas fa-heart" aria-hidden="true"></i>
                   </a>
                 {{/if}}
               </div>

--- a/client/templates/status/learning-item.html
+++ b/client/templates/status/learning-item.html
@@ -16,7 +16,7 @@
              <a href="{{pathFor 'profile' name=username userId=userId}}" class="{{#unless currentUser}} continue-popup {{/unless}}"><span class="username">{{username}}</span></a>
               <label class="status">
                   {{#if isOwner}}
-                    <span class="{{#unless currentUser}} continue-popup {{else}} delete-learning {{/unless}}"><i class="far fa-trash-alt"></i></span> <a class="{{#unless currentUser}} continue-popup {{else}} edit-learning {{/unless}}">(Edit)</a>
+                    <span class="{{#unless currentUser}} continue-popup {{else}} delete-learning {{/unless}}"><i class="fas fa-trash-alt"></i></span> <a class="{{#unless currentUser}} continue-popup {{else}} edit-learning {{/unless}}">(Edit)</a>
                   {{/if}}
               </label>
               <p class="learning-title">{{{ learningTitle }}}</p>

--- a/client/templates/status/status-item.html
+++ b/client/templates/status/status-item.html
@@ -5,7 +5,7 @@
        <span><i class="fas {{hangoutStatus}}"></i></span>
       </li>
       <li>
-        <label class="status">{{statusMessage}}</label>&nbsp;&nbsp;<a href="{{pathFor 'profile' name=username userId=_id}}"><span class="username">{{username}}</span></a> <a href="https://codebuddies.slack.com/messages/@{{username}}/" target="_blank" class="message"><i class="far fa-envelope"></i></a> - <span class="status-date">{{livestamp statusDate}}</span>
+        <label class="status">{{statusMessage}}</label>&nbsp;&nbsp;<a href="{{pathFor 'profile' name=username userId=_id}}"><span class="username">{{username}}</span></a> <a href="https://codebuddies.slack.com/messages/@{{username}}/" target="_blank" class="message"><i class="fas fa-envelope"></i></a> - <span class="status-date">{{livestamp statusDate}}</span>
       </li>
     </ul>
   </div>

--- a/client/templates/study_groups/study_group_discussion.html
+++ b/client/templates/study_groups/study_group_discussion.html
@@ -82,11 +82,11 @@
         </div>
         <div class="col-md-12">
           <h4>
-            <i class="far fa-thumbs-up {{#if isInCollection up_votes}} voted {{else}} upvote {{/if}}" aria-hidden="true"></i> <small>{{up_votes.length}}</small> &nbsp; &nbsp;
-            <i class="far fa-thumbs-down {{#if isInCollection down_votes}} voted {{else}} downvote {{/if}}" aria-hidden="true"></i> <small>{{down_votes.length}}</small> &nbsp; &nbsp;
-            <small><i class="far fa-clock" aria-hidden="true"></i> Posted on : {{dispDate created_at}} </small> &nbsp; &nbsp;
-            <small><i class="far fa-comments" aria-hidden="true"></i> {{response_count}} </small> &nbsp; &nbsp;
-            <small><i class="far fa-eye" aria-hidden="true"></i> {{views}} </small> &nbsp; &nbsp;
+            <i class="fas fa-thumbs-up {{#if isInCollection up_votes}} voted {{else}} upvote {{/if}}" aria-hidden="true"></i> <small>{{up_votes.length}}</small> &nbsp; &nbsp;
+            <i class="fas fa-thumbs-down {{#if isInCollection down_votes}} voted {{else}} downvote {{/if}}" aria-hidden="true"></i> <small>{{down_votes.length}}</small> &nbsp; &nbsp;
+            <small><i class="fas fa-clock" aria-hidden="true"></i> Posted on : {{dispDate created_at}} </small> &nbsp; &nbsp;
+            <small><i class="fas fa-comments" aria-hidden="true"></i> {{response_count}} </small> &nbsp; &nbsp;
+            <small><i class="fas fa-eye" aria-hidden="true"></i> {{views}} </small> &nbsp; &nbsp;
           </h4>
         </div>
       </div>


### PR DESCRIPTION
Wrote a small python script to search through the /client directory and find and replace "far fa-" with "fas-fa". 

Background: according to https://fontawesome.com/how-to-use/on-the-web/setup/upgrading-from-version-4#changes, we can only use `fab` and `fas` icons under the free plan. PRO plans cannot be used by open source projects.