### PR TITLE
add forum link in nav bar

### DIFF
--- a/client/templates/nav/header.html
+++ b/client/templates/nav/header.html
@@ -31,6 +31,11 @@
                     <i class="fab fa-slack-hash fa-fw" aria-hidden="true"></i>{{_ "slack"}}
                   </a></li>
                <li role="separator" class="divider"></li>
+               <li><a href="https://forum.codebuddies.org " target="_blank">
+                 <i class="fab fa-comments fa-fw" aria-hidden="true"></i>Forum
+                 <i class="fas fa-external-link-alt fa-fw" aria-hidden="true"></i>
+               </a></li>
+              <li role="separator" class="divider"></li>
                <li><a href="https://github.com/codebuddies/codebuddies" target="_blank">
                  <i class="fab fa-github fa-fw" aria-hidden="true"></i>Github
                  <i class="fas fa-external-link-alt fa-fw" aria-hidden="true"></i>

--- a/client/templates/nav/header.html
+++ b/client/templates/nav/header.html
@@ -32,7 +32,7 @@
                   </a></li>
                <li role="separator" class="divider"></li>
                <li><a href="https://forum.codebuddies.org " target="_blank">
-                 <i class="fab fa-comments fa-fw" aria-hidden="true"></i>Forum
+                 <i class="fab fa-discourse fa-fw" aria-hidden="true"></i>Forum
                  <i class="fas fa-external-link-alt fa-fw" aria-hidden="true"></i>
                </a></li>
               <li role="separator" class="divider"></li>


### PR DESCRIPTION
add https://forum.codebuddies.org link in nav bar, so new user, can
easily find code buddies forum link

Fixes #919 .
