### PR TITLE
Fix hangout link issue

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -88,6 +88,8 @@ meteortesting:mocha@1.0.0
 meteortoys:toykit@2.2.1
 minifier-js@2.3.5
 minimongo@1.4.4
+mizzao:timesync@0.5.0	
+mizzao:user-status@0.6.7
 mobile-experience@1.0.5
 mobile-status-bar@1.0.14
 modern-browsers@0.1.2

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -88,7 +88,7 @@ meteortesting:mocha@1.0.0
 meteortoys:toykit@2.2.1
 minifier-js@2.3.5
 minimongo@1.4.4
-mizzao:timesync@0.5.0	
+mizzao:timesync@0.5.0
 mizzao:user-status@0.6.7
 mobile-experience@1.0.5
 mobile-status-bar@1.0.14

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -83,11 +83,11 @@ meteorhacks:meteorx@1.4.1
 meteorhacks:picker@1.0.3
 meteorhacks:ssr@2.2.0
 meteorspark:util@0.2.0
+meteortesting:browser-tests@1.0.0
+meteortesting:mocha@1.0.0
 meteortoys:toykit@2.2.1
 minifier-js@2.3.5
 minimongo@1.4.4
-mizzao:timesync@0.5.0
-mizzao:user-status@0.6.7
 mobile-experience@1.0.5
 mobile-status-bar@1.0.14
 modern-browsers@0.1.2

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@
 # FAQ
 
 ## What is CodeBuddies?
-We're a community of independent code learners who help each other on [Slack](http://codebuddies.slack.com), [schedule hangouts](http://hangouts.codebuddies.org) to learn with each other, contribute to a periodic [anonymous crowdsourced newsletter](http://tinyletter.com/codebuddies) where anyone can share a personal project or leave a shout out, and post on [Facebook](https://www.facebook.com/groups/TOPSTUDYGROUP/). We come from all over the world; there are members living in the United States, Japan, Sweden, the United Kingdom, Russia, Australia, Canada, India, and more. We accept donations and are 100% transparent on [Open Collective](https://opencollective.com/codebuddies).
+We're a community of independent code learners who help each other on [Slack](http://codebuddies.slack.com), [schedule hangouts](https://codebuddies.org/hangouts) to learn with each other, contribute to a periodic [anonymous crowdsourced newsletter](http://tinyletter.com/codebuddies) where anyone can share a personal project or leave a shout out, and post on [Facebook](https://www.facebook.com/groups/TOPSTUDYGROUP/). We come from all over the world; there are members living in the United States, Japan, Sweden, the United Kingdom, Russia, Australia, Canada, India, and more. We accept donations and are 100% transparent on [Open Collective](https://opencollective.com/codebuddies).
 
 Learning with each other helps us learn faster. We strive to create a safe space for anyone interested in code to talk about the learning process. The project is free and open-sourced on Github, and this app is 100% community/volunteer-built.
 


### PR DESCRIPTION
Fixes #927 

I made a small edit to the README file to correct the Hangouts link that should point to this URL - https://codebuddies.org/hangouts instead of  http://hangouts.codebuddies.org/