### PR TITLE
Solves bug 930

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -88,6 +88,8 @@ meteortesting:mocha@1.0.0
 meteortoys:toykit@2.2.1
 minifier-js@2.3.5
 minimongo@1.4.4
+mizzao:timesync@0.5.0	
+mizzao:user-status@0.6.7
 mobile-experience@1.0.5
 mobile-status-bar@1.0.14
 modern-browsers@0.1.2

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -88,7 +88,7 @@ meteortesting:mocha@1.0.0
 meteortoys:toykit@2.2.1
 minifier-js@2.3.5
 minimongo@1.4.4
-mizzao:timesync@0.5.0	
+mizzao:timesync@0.5.0
 mizzao:user-status@0.6.7
 mobile-experience@1.0.5
 mobile-status-bar@1.0.14

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -83,11 +83,11 @@ meteorhacks:meteorx@1.4.1
 meteorhacks:picker@1.0.3
 meteorhacks:ssr@2.2.0
 meteorspark:util@0.2.0
+meteortesting:browser-tests@1.0.0
+meteortesting:mocha@1.0.0
 meteortoys:toykit@2.2.1
 minifier-js@2.3.5
 minimongo@1.4.4
-mizzao:timesync@0.5.0
-mizzao:user-status@0.6.7
 mobile-experience@1.0.5
 mobile-status-bar@1.0.14
 modern-browsers@0.1.2

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -83,8 +83,6 @@ meteorhacks:meteorx@1.4.1
 meteorhacks:picker@1.0.3
 meteorhacks:ssr@2.2.0
 meteorspark:util@0.2.0
-meteortesting:browser-tests@1.0.0
-meteortesting:mocha@1.0.0
 meteortoys:toykit@2.2.1
 minifier-js@2.3.5
 minimongo@1.4.4

--- a/client/templates/hangout/hangout-frame.html
+++ b/client/templates/hangout/hangout-frame.html
@@ -8,7 +8,7 @@
 </div>
 
 <div class="alert alert-info margin-top-1 margin-bottom-1">
-  <p class="align-center">If you're seeing a blank screen, <a href="https://meet.jit.si/cb{{_id}}#config.startWithVideoMuted=true" target="_blank" id="joinHere">join here.</a> (New to Jitsi? Check out <a href="/images/codebuddies_jitsi_diagram.jpg" target="_blank">this diagram</a>.)</p>
+  <p class="align-center">If you're seeing a blank screen, <a href="https://meet.jit.si/{{room}}#config.startWithVideoMuted=true" target="_blank" id="joinHere">join here.</a> (New to Jitsi? Check out <a href="/images/codebuddies_jitsi_diagram.jpg" target="_blank">this diagram</a>.)</p>
 </div>
   <div id="hangout-container"></div>
   {{#if numParticipants}}

--- a/client/templates/hangout/hangout-frame.js
+++ b/client/templates/hangout/hangout-frame.js
@@ -126,6 +126,9 @@ Template.hangoutFrame.helpers({
       return appState.participants.length;
     }
     return 0;
+  },
+  room: function() {
+    return Template.instance().room.get();
   }
 });
 


### PR DESCRIPTION
See: issue #930. Makes sure users following the 'blank screen' instructions for the 24x7 hangout don't end up in the wrong room.