### PR TITLE
feat - slack alert for 24/7

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -151,5 +151,3 @@ url@1.2.0
 webapp@1.6.2
 webapp-hashing@1.0.9
 zimme:active-route@2.3.2
-mizzao:timesync@0.5.0	
-mizzao:user-status@0.6.7

--- a/server/app_stats/methods.js
+++ b/server/app_stats/methods.js
@@ -5,7 +5,7 @@ Meteor.methods({
     // for guest user.
     const guestUser = {
       _id: "guest",
-      username: "username",
+      username: "guest",
       profile: {
         avatar: {
           default: "https://codebuddies.org/images/logo-circle.svg"
@@ -19,7 +19,7 @@ Meteor.methods({
 
     const participant = {
       id: actor._id,
-      username: "guest" || actor.username,
+      username: actor.username,
       avatar: actor.profile.avatar.default
     };
 
@@ -39,6 +39,10 @@ Meteor.methods({
         }
       }
     );
+
+    if (hangoutId == "cbcoworking") {
+      coworkingSlackAlert(participant.username);
+    }
   }
 });
 

--- a/server/slack/methods.js
+++ b/server/slack/methods.js
@@ -264,3 +264,30 @@ discussionsSlackAlert = function(discussion) {
     text: pretext
   });
 };
+
+/**
+ * slack alert for when someone joins the 24/7
+ * co-working hangout
+ * @function
+ * @name coworkingSlackAlert
+ * @param { String } username
+ * @return null
+ */
+coworkingSlackAlert = function(username = "guest") {
+  const channel = Meteor.isDevelopment
+    ? Meteor.settings.slack_alert_channel
+    : "#coworking";
+  coworkingAlert = slack.extend({
+    channel: channel,
+    icon_emoji: ":coworking:",
+    username: "Coworking 24/7"
+  });
+  const jitsiRoom =
+    "https://meet.jit.si/cbcoworking#config.startWithVideoMuted=true";
+
+  const pretext = `*${username}* _has joined the_ <${jitsiRoom}|24/7 coworking room>.`;
+
+  coworkingAlert({
+    text: pretext
+  });
+};

--- a/server/slack/methods.js
+++ b/server/slack/methods.js
@@ -285,7 +285,7 @@ coworkingSlackAlert = function(username = "guest") {
   const jitsiRoom =
     "https://meet.jit.si/cbcoworking#config.startWithVideoMuted=true";
 
-  const pretext = `*${username}* _has joined the_ <${jitsiRoom}|24/7 coworking room>.`;
+  const pretext = `*${username}* _has joined the_ <${jitsiRoom}|24/7 silent coworking> room.`;
 
   coworkingAlert({
     text: pretext


### PR DESCRIPTION
Fixes #922.

Whenever someone join the `24/7 co-working` jitsi room,  System will send the following alert to the `#coworking` channel.

```
<username || guest> has joined the 24/7 coworking room
```
<img width="561" alt="screen shot 2018-08-25 at 9 46 58 am" src="https://user-images.githubusercontent.com/11193792/44614994-df2c3f80-a84c-11e8-8d3f-dc6f2b8faf81.png">

