### PR TITLE
Fix Issue-932 

### DIFF
--- a/client/css/_base.scss
+++ b/client/css/_base.scss
@@ -198,3 +198,5 @@ a:hover {
 label#twitterWarning {
   font-weight: 400;
 }
+
+

--- a/client/css/_base.scss
+++ b/client/css/_base.scss
@@ -199,4 +199,8 @@ label#twitterWarning {
   font-weight: 400;
 }
 
-
+//cb-icons for slack.html
+.cb-icon {
+  width: 50px;
+  height: 50px;
+}

--- a/client/templates/other/slack.html
+++ b/client/templates/other/slack.html
@@ -44,7 +44,7 @@
               <h1>CodeBuddies Slack Etiquette for General Members</h1>
               <div class="divider"></div>
               <p>The following guidelines will help you get the most from our Slack community.</p>
-              <h2><img src="/images/logo-circle.png" style="width:50px;height:50px">Every member of CodeBuddies is a
+              <h2><img src="/images/logo-circle.png" class="cb-icon">Every member of CodeBuddies is a
                 person</h2>
               <p><b><i>This is a safe space.</i></b> No question is too "stupid", no topic too "basic".</p>
               <p>This community is intended for self-directed learners, CS students, programming enthusiasts, and
@@ -55,7 +55,7 @@
                 answer. Treat us like
                 somebody friendly you don’t know who’s standing next to you offering help or suggestions.</p>
               <hr>
-              <h2><img src="/images/logo-circle.png" style="width:50px;height:50px">CodeBuddies is asynchronous &amp;
+              <h2><img src="/images/logo-circle.png" class="cb-icon">CodeBuddies is asynchronous &amp;
                 international</h2>
               <p>We have members on every continent (except Antartica), and many of us are working professionals. You
                 may get help within
@@ -71,7 +71,7 @@
                 moment, but we <i>are</i> reading posts across all channels. Someone will eventually see (and help)
                 you.</p>
               <hr>
-              <h2><img src="/images/logo-circle.png" style="width:50px;height:50px">Some channels are more active than
+              <h2><img src="/images/logo-circle.png" class="cb-icon">Some channels are more active than
                 others</h2>
               <p>Questions in <b>#general</b> or <b>#advice</b> tend to get answered quickly, or they get pushed off
                 the screen &amp; forgotten. We have a
@@ -82,7 +82,7 @@
                 try posting a
                 question/article/or discussion point that others in the channel might comment on or enjoy.</p>
               <hr>
-              <h2><img src="/images/logo-circle.png" style="width:50px;height:50px">Don’t “ask to ask”</h2>
+              <h2><img src="/images/logo-circle.png" class="cb-icon">Don’t “ask to ask”</h2>
               <p>Newcomers very commonly ask about asking a question in one of a few ways.</p>
               <h3>“DOES ANYONE KNOW ABOUT [X TOOL OR LIBRARY]?”</h3>
               <p>The answer is probably “yes,” <b><i>but nobody can help you until you state what your problem is.</i></b>
@@ -108,7 +108,7 @@
                 moderators or other helpful users will suggest it, but don't worry - off topic messages aren’t going to
                 get you banned.</p>
               <hr>
-              <h2><img src="/images/logo-circle.png" style="width:50px;height:50px">Don’t ping / DM members unless it's
+              <h2><img src="/images/logo-circle.png" class="cb-icon">Don’t ping / DM members unless it's
                 directly relevant</h2>
               <p>It’s very tempting to try to get more attention to your question by @-mentioning one of the high
                 profile (or recently active)
@@ -122,7 +122,7 @@
                 people can learn from them when they’re
                 asked in a public channel.</p>
               <hr>
-              <h2><img src="/images/logo-circle.png" style="width:50px;height:50px">Be helpful</h2>
+              <h2><img src="/images/logo-circle.png" class="cb-icon">Be helpful</h2>
               <p><b><i>We are a pay-it-forward community.</i></b> If someone here has helped you, please give back by
                 helping someone else!</p>
               <p>It doesn’t matter if you can’t answer a question in a brief sentence, or if you get pulled away before
@@ -132,12 +132,12 @@
                 link. A lot of people who are stuck will be fine if you can’t provide the solution, they just need
                 another place to look.</p>
               <hr>
-              <h2><img src="/images/logo-circle.png" style="width:50px;height:50px">Be polite</h2>
+              <h2><img src="/images/logo-circle.png" class="cb-icon">Be polite</h2>
               <p>All the CodeBuddies here deserve your respect, so be polite. Not “retail employee” polite......but
                 don’t fan flamewars, get
                 sucked into lose-lose arguments, or other internet classics.</p>
               <hr>
-              <h2><img src="/images/logo-circle.png" style="width:50px;height:50px">Be a model Slack citizen</h2>
+              <h2><img src="/images/logo-circle.png" class="cb-icon">Be a model Slack citizen</h2>
               <p>Be the change you want to see in the world! <i>Remember ours runs on volunteers and collaboration.</i>
                 If a conversation is
                 getting heated, try to defuse it. If a hard question is unanswered, dig in &amp; work through it with
@@ -153,7 +153,7 @@
                   share it?
                   Absolutely! But please respect the following guidelines about posting commercial content:</p>
 
-                <h2><img src="/images/logo-circle.png" style="width:50px;height:50px">
+                <h2><img src="/images/logo-circle.png" class="cb-icon">
                   Commercial Post</h2>
                     <p>In general, all commercial posts can be shared in the <b>#promote</b> channel. These include links to ticket
                   sale pages to
@@ -162,13 +162,13 @@
                   you created that's behind a paywall.
                 </p>
                 <hr>
-                <h2><img src="/images/logo-circle.png" style="width:50px;height:50px"> Job postings</h2>
+                <h2><img src="/images/logo-circle.png" class="cb-icon"> Job postings</h2>
 
                 <p>If you want to hire someone or want to forward a job posting, we'd love for you to share the
                 opportunity in
                 <b>#job-postings</b>! Many members keep an eye out there for opportunities.</p>
                <hr>
-                <h2><img src="/images/logo-circle.png" style="width:50px;height:50px"> Promoting a paid book or course</h2>
+                <h2><img src="/images/logo-circle.png" class="cb-icon"> Promoting a paid book or course</h2>
                 <p>If you're the author of a course or a book that you think might benefit the community, congratulations
                 on the
                 achievement! Feel free to mention it casually in conversation so that members of the community can
@@ -181,7 +181,7 @@
                 community (eg
                 1-2 passes to your book or course), please fill out this form.</p>
                 <hr>
-                <h2><img src="/images/logo-circle.png" style="width:50px;height:50px"> Promoting conference ticket sales</h2>
+                <h2><img src="/images/logo-circle.png" class="cb-icon"> Promoting conference ticket sales</h2>
 
                 <p>If you're the organizer of a conference that isn't free to attend, but you want to share a link to the
                 ticket sales
@@ -194,7 +194,7 @@
                 anywhere/anytime.</p>
                 <hr>
 
-                <h2><img src="/images/logo-circle.png" style="width:50px;height:50px"> Looking for signups</h2>
+                <h2><img src="/images/logo-circle.png" class="cb-icon"> Looking for signups</h2>
                 <p>If you've started your own open source project/community and are looking for contributors to sign up to
                 a separate
                 Discord/Slack/Dicourse, etc. on an external link, please post the signup link in <b>#promote</b>. If the
@@ -208,7 +208,7 @@
                 feel free to share the event in the appropriate channel.</p>
                 <hr>
 
-                <h2><img src="/images/logo-circle.png" style="width:50px;height:50px"> Personal projects are fine to talk about anywhere</h2>
+                <h2><img src="/images/logo-circle.png" class="cb-icon"> Personal projects are fine to talk about anywhere</h2>
                 <p> Got a personal project that isn't behind a paywall that you want to share? Post it anywhere! We've got
                 a
                 <b>#personal-projects</b> channel where you can write about progress or victories. If the project happens to

--- a/client/templates/other/slack.html
+++ b/client/templates/other/slack.html
@@ -154,8 +154,8 @@
                   Absolutely! But please respect the following guidelines about posting commercial content:</p>
 
                 <h2><img src="/images/logo-circle.png" style="width:50px;height:50px">
-                  Commercial Post<h2>
-                    <p>In general, all commercial posts can be shared in the #promote channel. These include links to ticket
+                  Commercial Post</h2>
+                    <p>In general, all commercial posts can be shared in the <b>#promote</b> channel. These include links to ticket
                   sale pages to
                   conferences, requests for members of CodeBuddies to sign up to join an external link, or a link to
                   purchase a course
@@ -197,11 +197,11 @@
                 <h2><img src="/images/logo-circle.png" style="width:50px;height:50px"> Looking for signups</h2>
                 <p>If you've started your own open source project/community and are looking for contributors to sign up to
                 a separate
-                Discord/Slack/Dicourse, etc. on an external link, please post the signup link in #promote. If the
+                Discord/Slack/Dicourse, etc. on an external link, please post the signup link in <b>#promote</b>. If the
                 project you're
                 working on is open sourced and you're looking specifically for contributors, please post the Github
                 link to
-                #open-source-friday and also complete this CB Connect form. We have many members who are looking for
+                <b>#open-source-friday</b> and also complete this <a href='https://docs.google.com/forms/d/e/1FAIpQLSc-VEOq2v8Y5jXUXtByhiKunOBKfuJIgec0yP_WI37f1MqC9w/viewform' target='_blank'>CB Connect form</a>. We have many members who are looking for
                 open source
                 projects to contribute to, and we'd love to connect them with your project. If you organize a study
                 group/free meetup,
@@ -253,5 +253,4 @@
       </div>  
 
     </div>
-  </div>
 </template>

--- a/client/templates/other/slack.html
+++ b/client/templates/other/slack.html
@@ -179,7 +179,7 @@
 
                 <p>If your book/course is behind a paywall and you'd like to sponsor a giveaway that we'll announce to the
                 community (eg
-                1-2 passes to your book or course), please fill out this form.</p>
+                1-2 passes to your book or course), please fill out this <a href='https://docs.google.com/forms/d/e/1FAIpQLSem-thE5Btwb0t_sLlQc0uWkwS8rcPB-D9IUejBBOfeYGA9RA/viewform' target='_blank'>form</a>.</p>
                 <hr>
                 <h2><img src="/images/logo-circle.png" class="cb-icon"> Promoting conference ticket sales</h2>
 
@@ -189,7 +189,7 @@
                 want to share it
                 in both <b>#loc-nyc</b> and <b>#javascript</b>, please find out if you're able to give the CodeBuddies community a
                 discount or a free
-                ticket to raffle away. Then, please fill out this form. CFP links don't fall under the same scrutiny
+                ticket to raffle away. Then, please fill out this <a href='https://docs.google.com/forms/d/e/1FAIpQLSem-thE5Btwb0t_sLlQc0uWkwS8rcPB-D9IUejBBOfeYGA9RA/viewform' target='_blank'>form</a>. CFP links don't fall under the same scrutiny
                 and can be posted
                 anywhere/anytime.</p>
                 <hr>

--- a/client/templates/other/slack.html
+++ b/client/templates/other/slack.html
@@ -100,7 +100,7 @@
               <h3>“IS IT OKAY IF I ASK ABOUT [X TOOL OR LIBRARY] HERE?”</h3>
               <p>We have a dizzying array of channels, which we’re aware of and for which we apologize. We have utility
                 channels such as
-                #announcements, #general, #advice, etc. All our channels are listed alphabetically.</p>
+                <b>#announcements</b>, <b>#general</b>, <b>#advice</b>, etc. All our channels are listed alphabetically.</p>
               <p>Instead of asking, browse the Channels list for any that seem like obvious places to ask your
                 question. If you don’t see any
                 topics or Channels that fit, don’t hesitate to post it in <b>#general</b> or <b>#advice.</b> If there’s

--- a/client/templates/other/slack.html
+++ b/client/templates/other/slack.html
@@ -112,7 +112,7 @@
                   <h2><img src="/images/logo-circle.png" style="width:50px;height:50px">Be a model Slack citizen</h2>
                     <p>Be the change you want to see in the world! <i>Remember ours runs on volunteers and collaboration.</i> If a conversation is 
                       getting heated, try to defuse it. If a hard question is unanswered, dig in &amp; work through it with others. If a channel is full 
-                      of unanswered questions, mention in <b>#codebuddies-meta</b> that you’d like to take ownership of it.</p>
+                      of unanswered questions, mention in <b>#codebuddies-meta</b> that you’d like to take ownership of it.</p>                      
                 <hr>
                 <hr>
                 <p>Thanks to everyone who've been following these etiquette rules already! This community is <span style="color: blue; font-size: 20px"><i class="fas fa-globe-asia"></i></span> 

--- a/client/templates/other/slack.html
+++ b/client/templates/other/slack.html
@@ -2,140 +2,256 @@
   <div id="slack">
 
     <div class="section slack-top">
-        <div class="container">
-          <div class="row">
-              <div class="col-md-12 align-center">
-                <h2>Slack</h2>
-            </div>
+      <div class="container">
+        <div class="row">
+          <div class="col-md-12 align-center">
+            <h2>Slack</h2>
           </div>
+        </div>
       </div>
     </div>
     <div class="section slack-middle">
       <div class="container container-large">
         <div class="row align-center">
-            <div class="col-md-8 col-md-offset-2">
-              <h2>Our community spends a lot of time helping each other on Slack.</h2>
-              <div class="slack-window">
-                <img src="/images/slack-window.png" class="img-responsive" id="slack-screenshot">
-              </div>
+          <div class="col-md-8 col-md-offset-2">
+            <h2>Our community spends a lot of time helping each other on Slack.</h2>
+            <div class="slack-window">
+              <img src="/images/slack-window.png" class="img-responsive" id="slack-screenshot">
             </div>
+          </div>
         </div>
         <div class="row">
           <div class="col-md-4">
             <h3>Quick Links</h3>
             <br>
-              <ul>
-                <li><a href="http://codebuddies.slack.com" target="_blank">Slack</a> (<a href="http://codebuddiesmeet.herokuapp.com" target="_blank" >Get your invite</a>)</li>
-                <li><a href="https://www.facebook.com/groups/TOPSTUDYGROUP/" target="_blank">Facebook Group</a></li>
-                <li><a href="https://github.com/codebuddies/codebuddies">Github</a> - <a href="http://docs.codebuddies.org" target="_blank">Documentation</a> | <a href="https://github.com/codebuddies/codebuddies/pulls" target="_blank">Pull Requests</a>
-                </li>
-                <li><a href="http://twitter.com/codebuddiesmeet" target="_blank">Twitter</a></li>
-                <li><a href="http://opencollective.com/codebuddies">Open Collective</a></li>
-              </ul>
-            </div>
-            <div class="col-md-8">
-              <h3>How do I join the CodeBuddies Slack?</h3>
-                <p>Our community spends a lot of time helping each other on our <a href="https://codebuddies.slack.com">Slack chatroom</a>. To join, enter your email <a href="http://codebuddiesmeet.herokuapp.com/" target="_blank">here</a>.</p>
-              <div class="etiquette">  
-                <h1>CodeBuddies Slack Etiquette for General Members</h1>
-                  <div class="divider"></div>
-                  <p>The following guidelines will help you get the most from our Slack community.</p>
-                  <p>.</p>
-                  <h2><img src="/images/logo-circle.png" style="width:50px;height:50px">Every member of CodeBuddies is a person</h2>
-                    <p><b><i>This is a safe space.</i></b> No question is too "stupid", no topic too "basic".</p>
-                    <p>.</p>
-                    <p>This community is intended for self-directed learners, CS students, programming enthusiasts, and professional developers to
-                      share knowledge and techniques. The admins, moderators, and everyone else in CodeBuddies <b><i>are donating their spare time;</i></b> 
-                      nobody’s being paid. Our suggestions/answers may not always be correct, &amp; you may not always get an answer. Treat us like
-                      somebody friendly you don’t know who’s standing next to you offering help or suggestions.</p>
-                  <hr>
-                  <h2><img src="/images/logo-circle.png" style="width:50px;height:50px">CodeBuddies is asynchronous &amp; international</h2>
-                    <p>We have members on every continent (except Antartica), and many of us are working professionals. You may get help within
-                      5 minutes if somebody who knows the answer is looking for something to do, but it’s entirely possible that you won’t get a 
-                      response for an hour or day or more. If you’re asking about a less popular tool, or a specific edge case, you may even get 
-                      an answer <b><i>several days later.</i></b></p>
-                    <p>.</p>
-                    <p>So remember to keep CodeBuddies open in the background for a while after asking a question - or check back periodically.</p>
-                    <p>.</p>
-                    <p>Please don't cross post the same question in multiple channels. People in this community may not be super-chatty at any given
-                      moment, but we <i>are</i> reading posts across all channels. Someone will eventually see (and help) you.</p>
-                  <hr>
-                  <h2><img src="/images/logo-circle.png" style="width:50px;height:50px">Some channels are more active than others</h2>
-                    <p>Questions in <b>#general</b> or <b>#advice</b> tend to get answered quickly, or they get pushed off the screen &amp; forgotten. We have a
-                      handful of dedicated people that read the scrollback and try to answer forgotten questions, but there’s a lot of 
-                      discussion/movement happening, you may want to re-post.</p>
-                    <p>.</p>
-                    <p>Conversely, if a channel is particluarly quiet, please do not post "this channel is quiet". Instead, try posting a 
-                      question/article/or discussion point that others in the channel might comment on or enjoy.</p>
-                  <hr>
-                  <h2><img src="/images/logo-circle.png" style="width:50px;height:50px">Don’t “ask to ask”</h2>
-                    <p>Newcomers very commonly ask about asking a question in one of a few ways.</p>
-                    <p>.</p>
-                    <h3>“DOES ANYONE KNOW ABOUT [X TOOL OR LIBRARY]?”</h3>
-                      <p>The answer is probably “yes,” <b><i>but nobody can help you until you state what your problem is.</i></b> There are several questions to
-                        this effect every week, and all too often by the time somebody asks what the <b>real</b> question is, the person who needed help has disconnected.</p>
-                      <p>.</p>
-                      <p><b><i>Please be specific with your questions so all of us can help you even when you aren't online.</i></b> Share a code snippet, a link
-                        to where you're seeing the issue, a description of what is confusing you, and specifics on what you've tried so far. More 
-                        often than not, it also helps to paste your error logs into a snippet or text file 
-                        (<a href="https://get.slack.help/hc/en-us/articles/204145658-create-a-snippet">instructions here on how to do that in Slack</a>) 
-                        to accompany your question/issue.</p>
-                      <p>.</p>
-                    <h3>“IS IT OKAY IF I ASK ABOUT [X TOOL OR LIBRARY] HERE?”</h3>
-                      <p>We have a dizzying array of channels, which we’re aware of and for which we apologize. We have utility channels such as 
-                        #announcements, #general, #advice, etc. All our channels are listed alphabetically.</p>
-                      <p>.</p>
-                      <p>Instead of asking, browse the Channels list for any that seem like obvious places to ask your question. If you don’t see any 
-                        topics or Channels that fit, don’t hesitate to post it in <b>#general</b> or <b>#advice.</b> If there’s a better place for it, one of the 
-                        moderators or other helpful users will suggest it, but don't worry - off topic messages aren’t going to get you banned.</p>
-                  <hr>
-                  <h2><img src="/images/logo-circle.png" style="width:50px;height:50px">Don’t ping / DM members unless it's directly relevant</h2>
-                    <p>It’s very tempting to try to get more attention to your question by @-mentioning one of the high profile (or recently active) 
-                      members, but please don’t. They may not actually be online, they may not be able to help, and <i>they may be in a completely 
-                      different timezone</i> – nobody likes push notifications at 3 am from an impatient stranger.</p>
-                    <p>.</p>
-                    <p>Similarly, don’t DM other members without asking first. All of the same problems as @-mentioning apply, and <b><i>private 
-                      conversations can’t help anyone else.</i></b> Your questions are likely not unique, and other people can learn from them when they’re 
-                      asked in a public channel.</p>
-                  <hr>
-                  <h2><img src="/images/logo-circle.png" style="width:50px;height:50px">Be helpful</h2>
-                    <p><b><i>We are a pay-it-forward community.</i></b> If someone here has helped you, please give back by helping someone else!</p>
-                    <p>.</p>
-                    <p>It doesn’t matter if you can’t answer a question in a brief sentence, or if you get pulled away before you can type out further 
-                      replies. If a question isn’t clear, ask a clarifying question. If you remember something you read that seemed related, send a 
-                      link. A lot of people who are stuck will be fine if you can’t provide the solution, they just need another place to look.</p>
-                  <hr>
-                  <h2><img src="/images/logo-circle.png" style="width:50px;height:50px">Be polite</h2>
-                    <p>All the CodeBuddies here deserve your respect, so be polite. Not “retail employee” polite......but don’t fan flamewars, get 
-                      sucked into lose-lose arguments, or other internet classics.</p>
-                  <hr>
-                  <h2><img src="/images/logo-circle.png" style="width:50px;height:50px">Be a model Slack citizen</h2>
-                    <p>Be the change you want to see in the world! <i>Remember ours runs on volunteers and collaboration.</i> If a conversation is 
-                      getting heated, try to defuse it. If a hard question is unanswered, dig in &amp; work through it with others. If a channel is full 
-                      of unanswered questions, mention in <b>#codebuddies-meta</b> that you’d like to take ownership of it.</p>                      
-                <hr>
-                <hr>
-                <p>Thanks to everyone who've been following these etiquette rules already! This community is <span style="color: blue; font-size: 20px"><i class="fas fa-globe-asia"></i></span> 
-                  <b><i>international and distributed across timezones</i></b>, and it's nice to find that even with our diverse backgrounds, experience levels, and 
-                  nationalities, we have similar goals and can support each other <span style="color: rgb(248, 121, 142); font-size: 20px"><i class="fas fa-heart"></i></span>. 
-                  It's always a delight to be late-night coding – &amp; suddenly realize that halfway around the world, a cheerful hangout collaborator is pouring their first cup of coffee for the day.</p>
+            <ul>
+              <li><a href="http://codebuddies.slack.com" target="_blank">Slack</a> (<a href="http://codebuddiesmeet.herokuapp.com"
+                  target="_blank">Get your invite</a>)</li>
+              <li><a href="https://www.facebook.com/groups/TOPSTUDYGROUP/" target="_blank">Facebook Group</a></li>
+              <li><a href="https://github.com/codebuddies/codebuddies">Github</a> - <a href="http://docs.codebuddies.org"
+                  target="_blank">Documentation</a> | <a href="https://github.com/codebuddies/codebuddies/pulls" target="_blank">Pull
+                  Requests</a>
+              </li>
+              <li><a href="http://twitter.com/codebuddiesmeet" target="_blank">Twitter</a></li>
+              <li><a href="http://opencollective.com/codebuddies">Open Collective</a></li>
+            </ul>
+          </div>
+          <div class="col-md-8">
+            <h3>How do I join the CodeBuddies Slack?</h3>
+            <p>Our community spends a lot of time helping each other on our <a href="https://codebuddies.slack.com">Slack
+                chatroom</a>. To join, enter your email <a href="http://codebuddiesmeet.herokuapp.com/" target="_blank">here</a>.</p>
+            <div class="etiquette">
+              <h1>CodeBuddies Slack Etiquette for General Members</h1>
+              <div class="divider"></div>
+              <p>The following guidelines will help you get the most from our Slack community.</p>
+              <h2><img src="/images/logo-circle.png" style="width:50px;height:50px">Every member of CodeBuddies is a
+                person</h2>
+              <p><b><i>This is a safe space.</i></b> No question is too "stupid", no topic too "basic".</p>
+              <p>This community is intended for self-directed learners, CS students, programming enthusiasts, and
+                professional developers to
+                share knowledge and techniques. The admins, moderators, and everyone else in CodeBuddies <b><i>are
+                    donating their spare time;</i></b>
+                nobody’s being paid. Our suggestions/answers may not always be correct, &amp; you may not always get an
+                answer. Treat us like
+                somebody friendly you don’t know who’s standing next to you offering help or suggestions.</p>
+              <hr>
+              <h2><img src="/images/logo-circle.png" style="width:50px;height:50px">CodeBuddies is asynchronous &amp;
+                international</h2>
+              <p>We have members on every continent (except Antartica), and many of us are working professionals. You
+                may get help within
+                5 minutes if somebody who knows the answer is looking for something to do, but it’s entirely possible
+                that you won’t get a
+                response for an hour or day or more. If you’re asking about a less popular tool, or a specific edge
+                case, you may even get
+                an answer <b><i>several days later.</i></b></p>
+              <p>So remember to keep CodeBuddies open in the background for a while after asking a question - or check
+                back periodically.</p>
+              <p>Please don't cross post the same question in multiple channels. People in this community may not be
+                super-chatty at any given
+                moment, but we <i>are</i> reading posts across all channels. Someone will eventually see (and help)
+                you.</p>
+              <hr>
+              <h2><img src="/images/logo-circle.png" style="width:50px;height:50px">Some channels are more active than
+                others</h2>
+              <p>Questions in <b>#general</b> or <b>#advice</b> tend to get answered quickly, or they get pushed off
+                the screen &amp; forgotten. We have a
+                handful of dedicated people that read the scrollback and try to answer forgotten questions, but there’s
+                a lot of
+                discussion/movement happening, you may want to re-post.</p>
+              <p>Conversely, if a channel is particluarly quiet, please do not post "this channel is quiet". Instead,
+                try posting a
+                question/article/or discussion point that others in the channel might comment on or enjoy.</p>
+              <hr>
+              <h2><img src="/images/logo-circle.png" style="width:50px;height:50px">Don’t “ask to ask”</h2>
+              <p>Newcomers very commonly ask about asking a question in one of a few ways.</p>
+              <h3>“DOES ANYONE KNOW ABOUT [X TOOL OR LIBRARY]?”</h3>
+              <p>The answer is probably “yes,” <b><i>but nobody can help you until you state what your problem is.</i></b>
+                There are several questions to
+                this effect every week, and all too often by the time somebody asks what the <b>real</b> question is,
+                the person who needed help has disconnected.</p>
+              <p><b><i>Please be specific with your questions so all of us can help you even when you aren't online.</i></b>
+                Share a code snippet, a link
+                to where you're seeing the issue, a description of what is confusing you, and specifics on what you've
+                tried so far. More
+                often than not, it also helps to paste your error logs into a snippet or text file
+                (<a href="https://get.slack.help/hc/en-us/articles/204145658-create-a-snippet">instructions here on how
+                  to do that in Slack</a>)
+                to accompany your question/issue.</p>
+              <h3>“IS IT OKAY IF I ASK ABOUT [X TOOL OR LIBRARY] HERE?”</h3>
+              <p>We have a dizzying array of channels, which we’re aware of and for which we apologize. We have utility
+                channels such as
+                #announcements, #general, #advice, etc. All our channels are listed alphabetically.</p>
+              <p>Instead of asking, browse the Channels list for any that seem like obvious places to ask your
+                question. If you don’t see any
+                topics or Channels that fit, don’t hesitate to post it in <b>#general</b> or <b>#advice.</b> If there’s
+                a better place for it, one of the
+                moderators or other helpful users will suggest it, but don't worry - off topic messages aren’t going to
+                get you banned.</p>
+              <hr>
+              <h2><img src="/images/logo-circle.png" style="width:50px;height:50px">Don’t ping / DM members unless it's
+                directly relevant</h2>
+              <p>It’s very tempting to try to get more attention to your question by @-mentioning one of the high
+                profile (or recently active)
+                members, but please don’t. They may not actually be online, they may not be able to help, and <i>they
+                  may be in a completely
+                  different timezone</i> – nobody likes push notifications at 3 am from an impatient stranger.</p>
+              <p>.</p>
+              <p>Similarly, don’t DM other members without asking first. All of the same problems as @-mentioning
+                apply, and <b><i>private
+                    conversations can’t help anyone else.</i></b> Your questions are likely not unique, and other
+                people can learn from them when they’re
+                asked in a public channel.</p>
+              <hr>
+              <h2><img src="/images/logo-circle.png" style="width:50px;height:50px">Be helpful</h2>
+              <p><b><i>We are a pay-it-forward community.</i></b> If someone here has helped you, please give back by
+                helping someone else!</p>
+              <p>It doesn’t matter if you can’t answer a question in a brief sentence, or if you get pulled away before
+                you can type out further
+                replies. If a question isn’t clear, ask a clarifying question. If you remember something you read that
+                seemed related, send a
+                link. A lot of people who are stuck will be fine if you can’t provide the solution, they just need
+                another place to look.</p>
+              <hr>
+              <h2><img src="/images/logo-circle.png" style="width:50px;height:50px">Be polite</h2>
+              <p>All the CodeBuddies here deserve your respect, so be polite. Not “retail employee” polite......but
+                don’t fan flamewars, get
+                sucked into lose-lose arguments, or other internet classics.</p>
+              <hr>
+              <h2><img src="/images/logo-circle.png" style="width:50px;height:50px">Be a model Slack citizen</h2>
+              <p>Be the change you want to see in the world! <i>Remember ours runs on volunteers and collaboration.</i>
+                If a conversation is
+                getting heated, try to defuse it. If a hard question is unanswered, dig in &amp; work through it with
+                others. If a channel is full
+                of unanswered questions, mention in <b>#codebuddies-meta</b> that you’d like to take ownership of it.</p>
               </div>
-              <h3>How do you show your appreciation to someone on Slack?</h3>
-                <p>We use a bot called plusplus to applaud or encourage each other. For example, if @hermionegranger gives me a helpful answer to a question I asked in a channel, I might type @hermionegranger++.
+
+
+              <div class="etiquette">
+                <h1>Where should I share a commercial post on Slack?</h1>
+                <div class="divider"></div>
+                <p>Occasionally you'll want to promote a project you've been working on that asks for money. Should you
+                  share it?
+                  Absolutely! But please respect the following guidelines about posting commercial content:</p>
+
+                <h2><img src="/images/logo-circle.png" style="width:50px;height:50px">
+                  Commercial Post<h2>
+                    <p>In general, all commercial posts can be shared in the #promote channel. These include links to ticket
+                  sale pages to
+                  conferences, requests for members of CodeBuddies to sign up to join an external link, or a link to
+                  purchase a course
+                  you created that's behind a paywall.
+                </p>
+                <hr>
+                <h2><img src="/images/logo-circle.png" style="width:50px;height:50px"> Job postings</h2>
+
+                <p>If you want to hire someone or want to forward a job posting, we'd love for you to share the
+                opportunity in
+                <b>#job-postings</b>! Many members keep an eye out there for opportunities.</p>
+               <hr>
+                <h2><img src="/images/logo-circle.png" style="width:50px;height:50px"> Promoting a paid book or course</h2>
+                <p>If you're the author of a course or a book that you think might benefit the community, congratulations
+                on the
+                achievement! Feel free to mention it casually in conversation so that members of the community can
+                ahem, potentially
+                start study groups around the content you've created. Or potentially give you feedback/serve as beta
+                readers/ask you
+                interesting questions.</p>
+
+                <p>If your book/course is behind a paywall and you'd like to sponsor a giveaway that we'll announce to the
+                community (eg
+                1-2 passes to your book or course), please fill out this form.</p>
+                <hr>
+                <h2><img src="/images/logo-circle.png" style="width:50px;height:50px"> Promoting conference ticket sales</h2>
+
+                <p>If you're the organizer of a conference that isn't free to attend, but you want to share a link to the
+                ticket sales
+                page in specific channels -- e.g. if you are an organizing a global javascript conference in NYC, and
+                want to share it
+                in both <b>#loc-nyc</b> and <b>#javascript</b>, please find out if you're able to give the CodeBuddies community a
+                discount or a free
+                ticket to raffle away. Then, please fill out this form. CFP links don't fall under the same scrutiny
+                and can be posted
+                anywhere/anytime.</p>
+                <hr>
+
+                <h2><img src="/images/logo-circle.png" style="width:50px;height:50px"> Looking for signups</h2>
+                <p>If you've started your own open source project/community and are looking for contributors to sign up to
+                a separate
+                Discord/Slack/Dicourse, etc. on an external link, please post the signup link in #promote. If the
+                project you're
+                working on is open sourced and you're looking specifically for contributors, please post the Github
+                link to
+                #open-source-friday and also complete this CB Connect form. We have many members who are looking for
+                open source
+                projects to contribute to, and we'd love to connect them with your project. If you organize a study
+                group/free meetup,
+                feel free to share the event in the appropriate channel.</p>
+                <hr>
+
+                <h2><img src="/images/logo-circle.png" style="width:50px;height:50px"> Personal projects are fine to talk about anywhere</h2>
+                <p> Got a personal project that isn't behind a paywall that you want to share? Post it anywhere! We've got
+                a
+                <b>#personal-projects</b> channel where you can write about progress or victories. If the project happens to
+                fit in another
+                channel -- e.g. if you created a flashcard app that helps people brush up on core javascript concepts
+                -- try not to
+                crosspost the same link in too many channels, but feel to share it elsewhere, like in the <b>#javascript</b>
+                channel as well.</p>
+                <hr>
+
+                <p>We want to celebrate all the projects members are working on -- commercial or not -- but for the sanity
+                of all Slack
+                users who don't want to be jarred by paywalled content, please follow these guidelines.</p>
+
+                <hr>
+                <hr>
+                <p>Thanks to everyone who've been following these etiquette rules already! This community is <span
+                    style="color: blue; font-size: 20px"><i class="fas fa-globe-asia"></i></span>
+                  <b><i>international and distributed across timezones</i></b>, and it's nice to find that even with
+                  our diverse backgrounds, experience levels, and
+                  nationalities, we have similar goals and can support each other <span style="color: rgb(248, 121, 142); font-size: 20px"><i
+                      class="fas fa-heart"></i></span>.
+                  It's always a delight to be late-night coding – &amp; suddenly realize that halfway around the world,
+                  a cheerful hangout collaborator is pouring their first cup of coffee for the day.</p>
+                  </div>
+                    
+                  <h3>How do you show your appreciation to someone on Slack?</h3>
+                  <p>We use a bot called plusplus to applaud or encourage each other. For example, if @hermionegranger
+                  gives me a helpful answer to a question I asked in a channel, I might type @hermionegranger++.
                   Think of these points as virtual cookies. <span style="font-size: 20px; color: #1e90ff"><i class="fas fa-smile-wink"></i></span></p>
-            </div>
+        </div>
           </div>
         </div>
-    </div>
-
-    <div class="section slack-bottom">
-      <div class="container">
-        <div class="row">
-
-        </div>
       </div>
+
+      <div class="section slack-bottom">
+        <div class="container">
+          <div class="row">
+
+          </div>
+        </div>
+      </div>  
+
     </div>
-
   </div>
-
 </template>


### PR DESCRIPTION
Fixes issue #932 

The following changes were made:

1. Added information about commercial posting to the slack page
1. Moved the `cb-logo` styling to `base.scss` and removed inline styling
1. Removed unnecessary periods from the page as cited by @wuworkshop 

I would suggest this change is squashed into a single commit maybe as described by the issue created.
