### PR TITLE
Added hangout-learned to profile

### DIFF
--- a/client/templates/profile/profile.html
+++ b/client/templates/profile/profile.html
@@ -125,8 +125,10 @@
         <div class="col-md-6 profile-learnings">
           <div class="box">
             <h3>#TodayILearned</h3>
+            <!-- add learnings here-->
+            {{> hangoutLearned }}
           </div>
-
+          <!-- display learnings-->
           {{> profileLearnings }}
 
         </div>


### PR DESCRIPTION
Added text box from hangout-learned template so users can add learning directly from profile page in response to issue 991

Fixes #991

Added the hangout-learned text input to the profile page.
