### PR TITLE
Add a button to load more Study Groups

### DIFF
--- a/client/css/_buttons.scss
+++ b/client/css/_buttons.scss
@@ -272,3 +272,7 @@ li.delete-hangout, li.edit-hangout {
   margin: 0 auto;
   max-width: 340px;
 }
+
+.btn-load-more {
+    margin: 20px auto;
+}

--- a/client/templates/study_groups/all_study_groups.html
+++ b/client/templates/study_groups/all_study_groups.html
@@ -30,62 +30,62 @@
       {{> studyGroupsSearchResult}}
     {{/if}}
 
-
     {{#unless sgSearchMode}}
       <div class="container margin-top-2">
 
-        {{#if Template.subscriptionsReady}}
-          {{#if studyGroups.count}}
+        {{#if studyGroups.count}}
           <div class="row">
             {{#each studyGroups}}
 
               <div class="col-md-4">
-              <div class="well card">
-                <h4>
-                  <a href="{{pathFor 'study group' studyGroupSlug=slug studyGroupId=_id}}">  {{title}} </a>
-                  <br> <small>{{tagline}}</small> <small><i class="fas fa-users fa-fw"></i>{{members.length}}</small>
-                  {{#if numParticipants _id}}
-                  <small><i class="fas fa-laptop fa-fw"></i>{{ numParticipants _id }}</small>
-                  {{/if}}
-                  {{#if isInRole 'owner' _id}}
-                    <span class="label label-primary pull-right">Owner</span>
-                  {{/if}}
-                  {{#if isInRole 'admin' _id}}
-                    <span class="label label-primary pull-right">Admin</span>
-                  {{/if}}
-                  {{#if isInRole 'moderator' _id}}
-                    <span class="label label-primary pull-right">Moderator</span>
-                  {{/if}}
-                  {{#if isInRole 'member' _id}}
-                    <span class="label label-primary pull-right">Member</span>
-                  {{/if}}
+                <div class="well card">
+                  <h4>
+                    <a href="{{pathFor 'study group' studyGroupSlug=slug studyGroupId=_id}}">  {{title}} </a>
+                    <br> <small>{{tagline}}</small> <small><i class="fas fa-users fa-fw"></i>{{members.length}}</small>
+                    {{#if numParticipants _id}}
+                    <small><i class="fas fa-laptop fa-fw"></i>{{ numParticipants _id }}</small>
+                    {{/if}}
+                    {{#if isInRole 'owner' _id}}
+                      <span class="label label-primary pull-right">Owner</span>
+                    {{/if}}
+                    {{#if isInRole 'admin' _id}}
+                      <span class="label label-primary pull-right">Admin</span>
+                    {{/if}}
+                    {{#if isInRole 'moderator' _id}}
+                      <span class="label label-primary pull-right">Moderator</span>
+                    {{/if}}
+                    {{#if isInRole 'member' _id}}
+                      <span class="label label-primary pull-right">Member</span>
+                    {{/if}}
+                  </h4>
 
-                </h4>
+                  {{#unless isInRole 'owner, admin, moderator, member' _id }}
+                      <button class="btn btn-join-study-group {{#unless currentUser}} continue-popup {{else}} join-study-group {{/unless}}">{{_ "join_study_group"}}</button>
+                  {{/unless}}
 
-                {{#unless isInRole 'owner, admin, moderator, member' _id }}
-                    <button class="btn btn-join-study-group {{#unless currentUser}} continue-popup {{else}} join-study-group {{/unless}}">{{_ "join_study_group"}}</button>
-                {{/unless}}
-
-                {{#if isInRole 'admin, moderator, member' _id }}
-                    <button class="btn btn-leave-study-group">{{_ "leave_study_group"}}</button>
-                {{/if}}
+                  {{#if isInRole 'admin, moderator, member' _id }}
+                      <button class="btn btn-leave-study-group">{{_ "leave_study_group"}}</button>
+                  {{/if}}
+                </div>
               </div>
-              </div>
+
             {{/each}}
-            </div>
-          {{else}}
-
-          {{/if}}
-
-        {{else}}
-          {{> loading}}
-        {{/if}}<!-- ./Template.subscriptionsReady -->
-
-        {{#if status}}
-            <div class="well well--end-of-page">
-              <h5 class="text-center">You've reached the end of the page.</h5>
-            </div>
+          </div>
         {{/if}}
+
+        {{#unless Template.subscriptionsReady}}
+          {{> loading}}
+        {{/unless}}
+
+        <div class="row">
+          <div class="col-sm-6 col-sm-offset-3">
+            {{#unless status}}
+              <button id="loadMoreStudyGroups" class="btn btn-default btn-block btn-load-more">Load More</button>
+            {{else}}
+              <h5 class="align-center">There are no more study groups.</h5>
+            {{/unless}}
+          </div>
+        </div>
 
       </div>
     {{/unless}}

--- a/client/templates/study_groups/all_study_groups.js
+++ b/client/templates/study_groups/all_study_groups.js
@@ -26,7 +26,7 @@ Template.allStudyGroups.onCreated(function() {
   });
 
   instance.loadStudyGroups = function(flag = 1) {
-    return StudyGroups.find({}, { sort: { start: flag } });
+    return StudyGroups.find({}, { sort: { createdAt: flag } });
   };
 
   instance.addMoreStudyGroups = function(){

--- a/client/templates/study_groups/all_study_groups.js
+++ b/client/templates/study_groups/all_study_groups.js
@@ -25,33 +25,19 @@ Template.allStudyGroups.onCreated(function() {
     instance.subscribe("allHangoutParticipants", hangoutIds);
   });
 
-  instance.loadStudyGroups = function() {
-    return StudyGroups.find({}, { sort: { title: 1 } });
+  instance.loadStudyGroups = function(flag = 1) {
+    return StudyGroups.find({}, { sort: { start: flag } });
   };
-});
 
-Template.allStudyGroups.onRendered(function() {
-  let instance = this;
-  let studyGroupsFilter = instance.studyGroupsFilter.get() || "new";
-  instance.studyGroupsFilter.set(studyGroupsFilter);
-
-  instance.scrollHandler = function() {
-    if (
-      $(window).scrollTop() > $(document).height() - $(window).height() - 20 &&
-      !instance.flag.get()
-    ) {
-      if (StudyGroups.find().count() === instance.limit.get()) {
-        instance.limit.set(instance.limit.get() + 9);
-        $("body").addClass("stop-scrolling");
-      } else {
-        if (StudyGroups.find().count() < instance.limit.get()) {
-          instance.flag.set(true);
-        } else {
-        }
+  instance.addMoreStudyGroups = function(){
+    if(StudyGroups.find().count() == instance.limit.get()){
+      instance.limit.set(instance.limit.get() + 9);
+    } else{
+      if(StudyGroups.find().count() < instance.limit.get()){
+        instance.flag.set(true);
       }
     }
-  }.bind(instance);
-  $(window).on("scroll", instance.scrollHandler);
+  }
 });
 
 Template.allStudyGroups.helpers({
@@ -130,5 +116,8 @@ Template.allStudyGroups.events({
         }
       });
     }
+  },
+  "click #loadMoreStudyGroups" : function(event, template){
+    template.addMoreStudyGroups();
   }
 });

--- a/server/study_groups/publications.js
+++ b/server/study_groups/publications.js
@@ -37,7 +37,7 @@ Meteor.publish( 'allStudyGroups', function(limit, studyGroupsFilter) {
 
   let projection = new Object();
 
-  projection.fields = {"title" : 1, 'tagline':1, "slug" : 1, members: 1 };
+  projection.fields = {"title" : 1, 'tagline':1, "slug" : 1, "createdAt" : 1, members: 1 };
   projection.limit = limit;
 
   let options = new Object();


### PR DESCRIPTION
Fixes #938.

When lazy loading the scroll listener was triggered multiple times,
which caused the page view limit to increase before more Study Groups
had been loaded in. This set the status flag to true making it think
that there were no more Study Groups to show and didn't allow the user
to load any more in by further scrolling.

While investigating this issue I also discovered that when lazy loading,
the Study Groups would disappear and the loading status would
momentarily flash up. This was caused by `subscriptionsReady` being
false when getting more Study Groups.

Aligned Study Groups page with Hangouts page by replacing
`scrollHandler` with `addMoreStudyGroups`, and styling the load more
button to match.  This also removes a potentially performance intensive
listener to window scroll events.


