### PR TITLE
_home.scss: Replace hardcoded val with variable

### DIFF
--- a/client/css/_home.scss
+++ b/client/css/_home.scss
@@ -232,7 +232,7 @@
 
     .shadow-effect {
       @include box-shadow(0, 12px, 60, rgba(0, 0, 0, .5));
-      border: 2px solid #fff !important;
+      border: 2px solid $white !important;
     }
 
     %hangout-cards {


### PR DESCRIPTION
Just following on to the discussion from before, replacing the hardcoded CSS value with a variable.