### PR TITLE
Issue 987: black text on red button

### DIFF
--- a/client/css/_buttons.scss
+++ b/client/css/_buttons.scss
@@ -219,6 +219,10 @@ li.delete-hangout, li.edit-hangout {
   }
 }
 
+.delete-hangout.btn.btn-cb2.btn-danger {
+  color: $white;
+}
+
 #btn-load-more, #load-more-learnings {
   color: $cta-blue;
   margin: 10px 0;

--- a/client/templates/hangout/hangout_action_buttons.html
+++ b/client/templates/hangout/hangout_action_buttons.html
@@ -41,7 +41,7 @@
       <a href="#" class="delete-hangout btn btn-cb2"><i class="fas fa-trash-alt" aria-hidden="true"></i> Cancel Hangout</a>
     {{else}}
       {{#if isInRole 'admin,moderator,volunteer' 'CB'}}
-          <a href="#" class="edit-hangout btn btn-cb2">Edit Details<span class="label label-info">M</span> </a>
+          <a href="#" class="edit-hangout btn btn-cb2">Edit Details <span class="label label-info">M</span> </a>
       {{/if}}
       {{#if isInRole 'admin,moderator' 'CB'}}
         <a href="#" class="delete-hangout btn btn-cb2 btn-danger"><i class="fas fa-trash-alt" aria-hidden="true"></i>&nbsp; Delete <span class="label label-info">M</span> </a>


### PR DESCRIPTION
Fixes [#987](https://github.com/codebuddies/codebuddies/issues/987#issuecomment-426258546).

- Changed the text color on the `Delete` button from black to white.
- Added a space to the `M` icon on the `Edit` button.
![image](https://user-images.githubusercontent.com/8125356/46908190-206cd180-cf17-11e8-8d4a-1d12e823ff43.png)



