### PR TITLE
Remove the loading screen when loading more on Hangouts Page

### DIFF
--- a/client/templates/hangout/hangout_cards.html
+++ b/client/templates/hangout/hangout_cards.html
@@ -1,48 +1,42 @@
 <template name="hangoutCards">
-  {{#if Template.subscriptionsReady}}
-  <h3 class="hangouts-title">{{_ "upcoming_events"}}</h3>
-    <div id="active_hangouts">
 
-      {{#if liveHangoutsCount }}
-      {{/if}}
-      {{#each hangouts 1}}
-        {{#unless isHangoutCompleted end}}
-        <div class="card">
-          {{> hangoutCard}}
-        </div>
-        {{/unless}}
-      {{/each}}
-
-    </div>
-
-    <h3 class="hangouts-title">{{_ "past_events"}}</h3>
-    <div id="past_hangouts">
-      {{#if pastHangoutsCount }}
-      
-      {{/if}}
-      {{#each hangouts -1}}
-        {{#if isHangoutCompleted end}}
-         <div class="card">
-           {{> hangoutCard}}
-        </div>
-        {{/if}}
-      {{/each}}
-
-    </div>
-
-    {{#unless status}}
-
-      <div class="clear">
-        <button id="loadMore" class="btn btn-default btn-block">Load More</button>
-      </div>
-
-    {{else}}
-        <h5 class="align-center color-white">There are no more hangouts.</h5>
-    {{/unless}}
-
-  {{else}}
-
-    {{> loading}}
-
+  {{#if liveHangoutsCount }}
+    <h3 class="hangouts-title">{{_ "upcoming_events"}}</h3>
   {{/if}}
+
+  <div id="active_hangouts">
+    {{#each hangouts 1}}
+      {{#unless isHangoutCompleted end}}
+      <div class="card">
+        {{> hangoutCard}}
+      </div>
+      {{/unless}}
+    {{/each}}
+  </div>
+
+  {{#if pastHangoutsCount }}
+    <h3 class="hangouts-title">{{_ "past_events"}}</h3>
+  {{/if}}
+
+  <div id="past_hangouts">
+    {{#each hangouts -1}}
+      {{#if isHangoutCompleted end}}
+       <div class="card">
+         {{> hangoutCard}}
+      </div>
+      {{/if}}
+    {{/each}}
+  </div>
+
+  {{#unless status}}
+    <div class="clear">
+      <button id="loadMore" class="btn btn-default btn-block">Load More</button>
+    </div>
+  {{else}}
+      <h5 class="align-center color-white">There are no more hangouts.</h5>
+  {{/unless}}
+
+  {{#unless Template.subscriptionsReady}}
+    {{> loading}}
+  {{/unless}}
 </template>


### PR DESCRIPTION
Fixes #1003

When the Load More button is pressed, the hangouts disappear and
the loading state momentarily flashes up. This was caused by
`subscriptionsReady` being false when getting more Hangouts.

I also moved the current and past headers into the `if` conditionals to
only display if there are any current or past hangouts to display
