### PR TITLE
Removed slack invitation links from bottom of the home page

### DIFF
--- a/client/templates/home/home_logged_out.html
+++ b/client/templates/home/home_logged_out.html
@@ -284,11 +284,6 @@
       <div class="row">
         <div class="col-md-12">
           <h2>Start learning with us now!</h2>
-          <div class="join-slack">
-            <p>Get your Slack invite <a href="https://codebuddiesmeet.herokuapp.com" class="link" target="_blank">here</a>.
-            <br />Sign in with <a href="#" class="signIn link">Slack</a> or <a href="#" class="signInGithub link">Github</a>.
-            <br />Select <strong>CodeBuddies</strong> or sign into the <strong>codebuddies</strong>.slack.com team.</p>
-          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Fixes #1024 
