### PR TITLE
Change slack updates channel for dev mode

### DIFF
--- a/settings-development.json
+++ b/settings-development.json
@@ -35,7 +35,7 @@
   "slack": "https://hooks.slack.com/services/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",
   "email_from": "linda@codebuddies.org",
   "team_id":"T04AQ6GEY",
-  "slack_alert_channel": "#codebuddies-ops",
+  "slack_alert_channel": "#codebuddies-test-hangouts",
   "slack_alert_username": "CodeBuddies Alerts",
   "hangout_reminder_interval": "every 1 hour",
   "root_email":"codebuddiesdotorg@gmail.com",

--- a/settings-development.json
+++ b/settings-development.json
@@ -35,7 +35,7 @@
   "slack": "https://hooks.slack.com/services/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",
   "email_from": "linda@codebuddies.org",
   "team_id":"T04AQ6GEY",
-  "slack_alert_channel": "#codebuddies-test-hangouts",
+  "slack_alert_channel": "#codebuddies-test-hang",
   "slack_alert_username": "CodeBuddies Alerts",
   "hangout_reminder_interval": "every 1 hour",
   "root_email":"codebuddiesdotorg@gmail.com",


### PR DESCRIPTION
Fixes #1019.

Title says it all. Updated env settings to push slack updates to `#codebuddies-test-hangouts` channel in dev mode.
