### PR TITLE
Fix slack reminder alerts issue

### DIFF
--- a/private/email-hangout-reminder-two.html
+++ b/private/email-hangout-reminder-two.html
@@ -13,7 +13,7 @@
           <tr> 
               <td>
 			     <p style="margin: 0px;">Hi there!</p>
-			     <p style="margin: 0px;">The hangout titled <strong><a href="{{hangout_url}}"> {{hangout_topic}}</a></strong> is set to start within 24 hours! We are sending you this friendly reminder because you RSVPed to the hangout. This hangout was scheduled by <a href="https://codebuddies.slack.com/messages/@{{host}}">@{{host}}</a> and will start at <strong>{{hangout_start_time}}</strong>, although you might want to click through to the page to double check the starting time in case the organizer has changed updated the details.
+			     <p style="margin: 0px;">The hangout titled <strong><a href="{{hangout_url}}"> {{hangout_topic}}</a></strong> is set to start within 24 hours! We are sending you this friendly reminder because you RSVPed to the hangout. This hangout was scheduled by <a href="https://codebuddies.slack.com/messages/@{{host}}">@{{host}}</a> and will start at <strong>{{hangout_start_time}}</strong>, although you might want to click through to the page to double check the starting time in case the organizer has changed updated the details.</p>
 			<p>Please update your RSVP if you can't make the hangout anymore. We hope to see you there!</p>
 
             <h2 style="margin:0; mso-line-height-rule:exactly;font-family: Arial;font-size: 30px;color: #0089FF;">Got something to share or teach?</h2>

--- a/settings-development.json
+++ b/settings-development.json
@@ -35,7 +35,7 @@
   "slack": "https://hooks.slack.com/services/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",
   "email_from": "linda@codebuddies.org",
   "team_id":"T04AQ6GEY",
-  "slack_alert_channel": "#codebuddies-ops",
+  "slack_alert_channel": "#announcements",
   "slack_alert_username": "CodeBuddies Alerts",
   "hangout_reminder_interval": "every 1 hour",
   "root_email":"codebuddiesdotorg@gmail.com",


### PR DESCRIPTION
Fixes #1020 

I just change the `slack_alert_channel` configuration in `settings-development.json` to #annoucnements so that the slack reminder alert will notify to the #announcements channel.
I fix some issue in the email template for the reminder.
