### PR TITLE
Remove unnecessary alert from clone hangout action

### DIFF
--- a/client/templates/hangout/hangout-clone.js
+++ b/client/templates/hangout/hangout-clone.js
@@ -102,7 +102,6 @@ Template.cloneHangoutModal.events({
     );
     const externalButtonText = $('input[name="externalButtonText"]').val();
     const externalURL = $('input[name="externalURL"]').val();
-    alert(externalURL);
 
     const data = {
       topic: topic,


### PR DESCRIPTION
When a user clicked to duplicate a hangout, they'd get an extra alert. This is now removed.