### PR TITLE
Adding color style to unlike button

### DIFF
--- a/client/css/_buttons.scss
+++ b/client/css/_buttons.scss
@@ -177,7 +177,7 @@
   color: $white;
 
   &.btn-unlike {
-    color: $cta-blue;
+    color: $cta-red;
   }
 
   &.btn-like {

--- a/client/css/_colors.scss
+++ b/client/css/_colors.scss
@@ -5,6 +5,7 @@ $bg-white: #fff;
 //Other colors
 $header-bg: #3D5A96;
 $cta-blue: #1e90ff;
+$cta-red: #e60000;
 $banner: #90ff1e;
 $light-blue: #5eafff;
 $kudo: #9b9b9b;


### PR DESCRIPTION
Fixes #588 

In order to support downvoting of a like for a Learning, I have added a color variable named cta-red and styled the kudo to become red once it has been liked. This is to show that the kudo can now be pressed again as a sign of un-liking a Learning.