### PR TITLE
Update print width from default for configs

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "lint-staged": {
     "*.{js,json,css}": [
-      "prettier --write",
+      "prettier --write --print-width 100",
       "git add"
     ]
   },


### PR DESCRIPTION
Fixes #1045 

Briefly saw that the length of prettier line breaks need to be longer than default. Looked up and then tested the command. 

referenced https://prettier.io/docs/en/options.html#print-width

<img width="476" alt="screen shot 2018-10-27 at 2 41 58 pm" src="https://user-images.githubusercontent.com/5950956/47608652-b3693980-d9f6-11e8-8b38-c0814fcd7ab1.png">

