### PR TITLE
Updated CB homepage copy

### DIFF
--- a/client/templates/home/home_logged_out.html
+++ b/client/templates/home/home_logged_out.html
@@ -32,8 +32,8 @@
 
           <div id="intro">
             <h2>Learn and chat about code!</h2>
-            <p class="intro">CodeBuddies is a community of 4000+ code learners who help each other through conversations on <strong>Slack</strong> and peer-to-peer organized <strong>study groups</strong> and <strong>virtual hangouts</strong>.</p>
-            <p>This project is free and <a href="http://opencollective.com/codebuddies" target="_blank" class="link">transparent on Open Collective</a>, non-profit, <a href="https://github.com/codebuddies/codebuddies" target="_blank" class="link">open-sourced</a>, and powered by a fantastic team of core volunteer <a href="/about" class="link">contributors</a>.</p>
+            <p class="intro">CodeBuddies is a global community of code learners who help each other through conversations on <strong>Slack</strong> and peer-to-peer organized <strong>study groups</strong> and <strong>virtual hangouts</strong>.</p>
+            <p>This project is free and <a href="http://opencollective.com/codebuddies" target="_blank" class="link">transparent on Open Collective</a>, non-for-profit, <a href="https://github.com/codebuddies/codebuddies" target="_blank" class="link">open-sourced</a>, and powered by a fantastic team of core volunteer <a href="/about" class="link">contributors</a>.</p>
             <div class="join-slack">
               <p>Get your Slack invite <a href="https://codebuddiesmeet.herokuapp.com" class="link" target="_blank">here</a>.</p>
               <p>Sign in with <a href="#" class="signIn link">Slack</a> or <a href="#" class="signInGithub link">Github</a>.

--- a/client/templates/home/home_logged_out.html
+++ b/client/templates/home/home_logged_out.html
@@ -33,7 +33,7 @@
           <div id="intro">
             <h2>Learn and chat about code!</h2>
             <p class="intro">CodeBuddies is a global community of code learners who help each other through conversations on <strong>Slack</strong> and peer-to-peer organized <strong>study groups</strong> and <strong>virtual hangouts</strong>.</p>
-            <p>This project is free and <a href="http://opencollective.com/codebuddies" target="_blank" class="link">transparent on Open Collective</a>, non-for-profit, <a href="https://github.com/codebuddies/codebuddies" target="_blank" class="link">open-sourced</a>, and powered by a fantastic team of core volunteer <a href="/about" class="link">contributors</a>.</p>
+            <p>This project is free and <a href="http://opencollective.com/codebuddies" target="_blank" class="link">transparent on Open Collective</a>, not-for-profit, <a href="https://github.com/codebuddies/codebuddies" target="_blank" class="link">open-sourced</a>, and powered by a fantastic team of core volunteer <a href="/about" class="link">contributors</a>.</p>
             <div class="join-slack">
               <p>Get your Slack invite <a href="https://codebuddiesmeet.herokuapp.com" class="link" target="_blank">here</a>.</p>
               <p>Sign in with <a href="#" class="signIn link">Slack</a> or <a href="#" class="signInGithub link">Github</a>.


### PR DESCRIPTION
Fixes #1051.

Updated the copy on the home page to read:

>  CodeBuddies is a global community of code learners who help each other through conversations on Slack and peer-to-peer organized study groups and virtual hangouts.

> This project is free and transparent on Open Collective, not-for-profit, open-sourced, and powered by a fantastic team of core volunteer contributors.

Maintained the styling of the copy on the homepage.