### PR TITLE
Add the #mud channel to the list of Slack notification channels

### DIFF
--- a/imports/data/discussion_tags.js
+++ b/imports/data/discussion_tags.js
@@ -38,6 +38,6 @@ export default discussion_tags  = [
   "sql-lite",
   "vuejs",
   "virtual-reality",
-  "wordpress"
-
+  "wordpress",
+  "mud"
 ]

--- a/imports/data/slack_channels.js
+++ b/imports/data/slack_channels.js
@@ -29,5 +29,6 @@ export default slack_channels = [
   "#security",
   "#vuejs",
   "#wordpress",
-  "#water-cooler"
+  "#water-cooler",
+  "#mud"
 ]


### PR DESCRIPTION
add mud to the list of channels in these two files: imports/data/slack_channels.js and imports/data/discussion_tags.js

Fixes #\<1064\>.