### PR TITLE
Anchor link added issue #1044

### DIFF
--- a/client/css/_slack.scss
+++ b/client/css/_slack.scss
@@ -22,7 +22,7 @@
 
   .etiquette {
     h1 { margin-top: 60px; margin-right: 0px; margin-bottom: 20px; margin-left: 0px;
-      font-size: 34px; font-weight: 700; letter-spacing: -.03rem}
+      font-size: 34px; font-weight: 700; letter-spacing: -.03rem; color: #333;}
     h2 { font-size: 27px; font-weight: 600; line-height: 33px; letter-spacing: -1px; margin-right: 0px;
       margin-bottom: 0px; margin-left: 0px;}
     h3 { font-size: 15px; font-weight: 800; line-height: 22px; min-height: 22px;

--- a/client/templates/other/slack.html
+++ b/client/templates/other/slack.html
@@ -1,4 +1,4 @@
-<template name="slack">
+﻿<template name="slack">
   <div id="slack">
 
     <div class="section slack-top">
@@ -146,8 +146,8 @@
               </div>
 
 
-              <div class="etiquette">
-                <h1>Where should I share a commercial post on Slack?</h1>
+              <div class="etiquette" id="commercial">
+                <a href="#commercial"><h1>Where should I share a commercial post on Slack?</h1></a>
                 <div class="divider"></div>
                 <p>Occasionally you'll want to promote a project you've been working on that asks for money. Should you
                   share it?


### PR DESCRIPTION
Fixes # 1044

Added an anchor tag to the <h 1>Where should I share a commercial post on Slack?</h 1> on codebuddies.org/slack page, so that users can type in https://codebuddies.org/slack#commercial and land directly on that section of the page.
