### PR TITLE
remove column names and add created by to discussion item

### DIFF
--- a/client/templates/discussion/all_discussions.html
+++ b/client/templates/discussion/all_discussions.html
@@ -40,13 +40,7 @@
       {{#if Template.subscriptionsReady}}
         {{#if discussions.count}}
           <div class="row">
-            <div class="col-md-8">
-              <h4>Topic</h4>
-            </div>
-            <div class="col-md-2">
-              <h4>Author</h4>
-            </div>
-            <div class="col-md-2">
+            <div class="col-md-12">
               <div class="dropdown pull-right">
                 <button class="btn btn-default dropdown-toggle" type="button" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
                     <span><i class="fas fa-filter" aria-hidden="true"></i></span>

--- a/client/templates/discussion/discussion_item.html
+++ b/client/templates/discussion/discussion_item.html
@@ -1,12 +1,10 @@
 <template name="discussionItem">
   <div class="row">
-    <div class="col-md-8">
+    <div class="col-md-10">
       <h4><a href="{{pathFor 'discussion' discussionId=_id}}">{{topic}}</a> {{#if modified_at}}<small>(Edited)</small>{{/if}}</h4>
+      <h5><small>Created By: </small><a href="{{pathFor 'profile' name=author.username userId=author.id}}">{{author.username}}</a></h5>
       <h5>{{#each tag in tags}} <span class="label label-default select-tag pointer" data-tag="{{tag}}">{{tag}}</span> {{/each}}</h5>
       <h4><small>{{truncateIt description '90'}}</small></h4>
-    </div>
-    <div class="col-md-2">
-      <h5><a href="{{pathFor 'profile' name=author.username userId=author.id}}">{{author.username}}</a></h5>
     </div>
     <div class="col-md-2">
       {{! available actions as a button grouping }}

--- a/client/templates/discussion/discussion_item.html
+++ b/client/templates/discussion/discussion_item.html
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col-md-10">
       <h4><a href="{{pathFor 'discussion' discussionId=_id}}">{{topic}}</a> {{#if modified_at}}<small>(Edited)</small>{{/if}}</h4>
-      <h5><small>Created By: </small><a href="{{pathFor 'profile' name=author.username userId=author.id}}">{{author.username}}</a></h5>
+      <h5><small>Started by <a href="{{pathFor 'profile' name=author.username userId=author.id}}">{{author.username}}</a></small></h5>
       <h5>{{#each tag in tags}} <span class="label label-default select-tag pointer" data-tag="{{tag}}">{{tag}}</span> {{/each}}</h5>
       <h4><small>{{truncateIt description '90'}}</small></h4>
     </div>


### PR DESCRIPTION
Fixes #1120.

As discussed in the ticket I have removed the column name and added the author to the discussion item.

Desktop:
<img width="1257" alt="disscussion_full" src="https://user-images.githubusercontent.com/3340414/54088553-a1e55600-4335-11e9-85f6-a3b80fadb88f.png">

Mobile:
<img width="644" alt="disscussion_mobile" src="https://user-images.githubusercontent.com/3340414/54088557-ac9feb00-4335-11e9-9b6c-b0e86dfb366d.png">
