### PR TITLE
Remove semicolon in timestamp of a comment

### DIFF
--- a/client/templates/discussion/discussion_card.html
+++ b/client/templates/discussion/discussion_card.html
@@ -52,7 +52,7 @@
       <h4>
         <i class="fas fa-thumbs-up {{#unless currentUser}} continue-popup {{else}} {{#if isInCollection up_votes}} voted {{else}} upvote {{/if}} {{/unless}}" aria-hidden="true"></i> <small>{{up_votes.length}}</small> &nbsp; &nbsp;
         <i class="fas fa-thumbs-down {{#unless currentUser}} continue-popup {{else}} {{#if isInCollection down_votes}} voted {{else}} downvote {{/if}} {{/unless}}" aria-hidden="true"></i> <small>{{down_votes.length}}</small> &nbsp; &nbsp;
-        <small><i class="fas fa-clock" aria-hidden="true"></i> Posted on: {{dispDate created_at}} </small> &nbsp; &nbsp;
+        <small><i class="fas fa-clock" aria-hidden="true"></i> Posted on {{dispDate created_at}} </small> &nbsp; &nbsp;
         <small><i class="fas fa-comments" aria-hidden="true"></i> {{response_count}} </small> &nbsp; &nbsp;
         <small><i class="fas fa-eye" aria-hidden="true"></i> {{views}} </small> &nbsp; &nbsp;
       </h4>

--- a/client/templates/discussion/discussion_item.html
+++ b/client/templates/discussion/discussion_item.html
@@ -45,7 +45,7 @@
       <h4>
         <i class="fas fa-thumbs-up  {{#unless currentUser}} continue-popup {{else}} {{#if isInCollection up_votes}} voted {{else}} upvote {{/if}} {{/unless}}" aria-hidden="true"></i> <small>{{up_votes.length}}</small> &nbsp; &nbsp;
         <i class="fas fa-thumbs-down {{#unless currentUser}} continue-popup {{else}} {{#if isInCollection down_votes}} voted {{else}} downvote {{/if}} {{/unless}}" aria-hidden="true"></i> <small>{{down_votes.length}}</small> &nbsp; &nbsp;
-        <small><i class="fas fa-clock" aria-hidden="true"></i> Posted on : {{dispDate created_at}} </small> &nbsp; &nbsp;
+        <small><i class="fas fa-clock" aria-hidden="true"></i> Posted on {{dispDate created_at}} </small> &nbsp; &nbsp;
         <small><i class="fas fa-comments" aria-hidden="true"></i> {{response_count}} </small> &nbsp; &nbsp;
         <small><i class="fas fa-eye" aria-hidden="true"></i> {{views}} </small> &nbsp; &nbsp;
       </h4>

--- a/client/templates/discussion/discussion_response_card.html
+++ b/client/templates/discussion/discussion_response_card.html
@@ -33,7 +33,7 @@
         <h4>
           <i class="fas fa-thumbs-up {{#if isInCollection up_votes}} upvoted {{else}} rupvote {{/if}}" aria-hidden="true"></i> <small>{{up_votes.length}}</small> &nbsp; &nbsp;
           <i class="fas fa-thumbs-down {{#if isInCollection down_votes}} downvoted {{else}} rdownvote {{/if}}" aria-hidden="true"></i> <small>{{down_votes.length}}</small> &nbsp; &nbsp;
-          <small><i class="fas fa-clock" aria-hidden="true"></i> Posted on: {{dispDate created_at}} </small> &nbsp; &nbsp;
+          <small><i class="fas fa-clock" aria-hidden="true"></i> Posted on {{dispDate created_at}} </small> &nbsp; &nbsp;
           <small>{{#if modified_at}}(Edited){{/if}}</small> &nbsp; &nbsp;
         </h4>
 
@@ -46,7 +46,7 @@
         </div>
         <hr>
         <h4>
-          <small><i class="fas fa-clock" aria-hidden="true"></i> Posted on: {{dispDate created_at}} </small> &nbsp; &nbsp;
+          <small><i class="fas fa-clock" aria-hidden="true"></i> Posted on {{dispDate created_at}} </small> &nbsp; &nbsp;
         </h4>
       </div>
     {{/if}}

--- a/client/templates/study_groups/study_group_discussion.html
+++ b/client/templates/study_groups/study_group_discussion.html
@@ -84,7 +84,7 @@
           <h4>
             <i class="fas fa-thumbs-up {{#if isInCollection up_votes}} voted {{else}} upvote {{/if}}" aria-hidden="true"></i> <small>{{up_votes.length}}</small> &nbsp; &nbsp;
             <i class="fas fa-thumbs-down {{#if isInCollection down_votes}} voted {{else}} downvote {{/if}}" aria-hidden="true"></i> <small>{{down_votes.length}}</small> &nbsp; &nbsp;
-            <small><i class="fas fa-clock" aria-hidden="true"></i> Posted on : {{dispDate created_at}} </small> &nbsp; &nbsp;
+            <small><i class="fas fa-clock" aria-hidden="true"></i> Posted on {{dispDate created_at}} </small> &nbsp; &nbsp;
             <small><i class="fas fa-comments" aria-hidden="true"></i> {{response_count}} </small> &nbsp; &nbsp;
             <small><i class="fas fa-eye" aria-hidden="true"></i> {{views}} </small> &nbsp; &nbsp;
           </h4>


### PR DESCRIPTION
An aesthetic template improvement only.

There's no linked issue becuz it is a small template improvement that @lpatmo and I had briefly discussed on slack: https://codebuddies.slack.com/archives/DF15G6FLK/p1552347053030200 

BEFORE
![Screen Shot 2019-03-12 at 12 30 05 AM](https://user-images.githubusercontent.com/954858/54183316-1ff24b80-4461-11e9-967b-25074c850bc8.png)

AFTER
![Screen Shot 2019-03-12 at 12 42 51 AM](https://user-images.githubusercontent.com/954858/54183317-1ff24b80-4461-11e9-86a2-21dec78d993e.png)
