### PR TITLE
Resolving Issue-1098

### DIFF
--- a/client/css/_study_groups.scss
+++ b/client/css/_study_groups.scss
@@ -42,7 +42,16 @@
     color: $danger-red;
   }
   .card {
-    @media screen and (min-width: 992px) { height: 190px; padding: 19px 19px 10px; }
+    @media screen and (min-width: 992px) {
+      height: 190px;
+      padding: 19px 19px 10px;
+      h4 a {
+        display: block;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+    }
     @include breakpoint(large) { height: 190px; padding: 19px 19px 10px; }
   }
   p {

--- a/client/css/_study_groups.scss
+++ b/client/css/_study_groups.scss
@@ -45,11 +45,19 @@
     @media screen and (min-width: 992px) {
       height: 190px;
       padding: 19px 19px 10px;
-      h4 a {
-        display: block;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
+      h4 {
+        a {
+          display: block;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+        small.tagline {
+          overflow-y: auto;
+          display: block;
+          max-height: 2.5rem;
+          line-height: 1.5;
+        }
       }
     }
     @include breakpoint(large) { height: 190px; padding: 19px 19px 10px; }

--- a/client/css/_study_groups.scss
+++ b/client/css/_study_groups.scss
@@ -42,7 +42,7 @@
     color: $danger-red;
   }
   .card {
-    @include breakpoint(medium) { height: 190px; padding: 19px 19px 10px; }
+    @media screen and (min-width: 992px) { height: 190px; padding: 19px 19px 10px; }
     @include breakpoint(large) { height: 190px; padding: 19px 19px 10px; }
   }
   p {

--- a/client/templates/study_groups/all_study_groups.html
+++ b/client/templates/study_groups/all_study_groups.html
@@ -7,7 +7,7 @@
         </div>
         <div class="col-md-8 col-md-offset-2">
           <p>
-              Start or join groups to hold each other accountable to learning goals.</p> 
+              Start or join groups to hold each other accountable to learning goals.</p>
               <p>In each group, you are given a 24/7 hangout room, a forum, the ability to schedule hangouts in that group, and a variety of group owner settings like the ability to auto-notify Slack channels whenever a new group meeting is scheduled.
           </p>
         </div>
@@ -42,7 +42,7 @@
                 <div class="well card">
                   <h4>
                     <a href="{{pathFor 'study group' studyGroupSlug=slug studyGroupId=_id}}">  {{title}} </a>
-                    <br> <small>{{tagline}}</small> <small class="members"><i class="fas fa-users fa-fw"></i>{{members.length}}</small>
+                    <br> <small class="tagline">{{tagline}}</small> <small class="members"><i class="fas fa-users fa-fw"></i>{{members.length}}</small>
                     {{#if updatedAt}}
                     <br> <small><b>Last Activity: </b> {{ relativeTime updatedAt }}</small>
                     {{/if}}


### PR DESCRIPTION
Fixes Issue #1098 .

Bootstrap's `col-md-4` on the card divs on the study group page causes each card to get a width of ~33% on screens greater than 992px wide. There is a SCSS rule that manually sets the height of the cards, but this only takes effect at 993px and up. So there's a 1px range at 992px, where there is no set height, so the cards' heights vary dependng on how much content is inside. I fixed this by changing the media query in the study-groups scss file.

However, this results in some potential UI issues if the content of the card (either the title of the study group or the tagline/description) is too long. Fixed this by forcing the title to only be 1 line of text, with an ellipses if it overflows + setting a max height for the tag line, with a scroll bar if needed. 

Let me know if any further changes are needed or if one of the above proposed resolutions is insufficient. 😄 

Before: 
<img width="986" alt="Screen Shot 2019-10-11 at 3 49 56 PM" src="https://user-images.githubusercontent.com/9094098/66680870-7a45cb80-ec3f-11e9-87bd-d08abac3f305.png">
![BEFORE](https://user-images.githubusercontent.com/9094098/66709530-662fc600-ed34-11e9-9b6e-476bff733c43.gif)





**After:**
<img width="963" alt="Screen Shot 2019-10-11 at 3 49 35 PM" src="https://user-images.githubusercontent.com/9094098/66709520-1e10a380-ed34-11e9-9dcc-e910a84736d0.png">
![GOOD](https://user-images.githubusercontent.com/9094098/66709555-c32b7c00-ed34-11e9-88fb-0dae425f6f76.gif)



